### PR TITLE
[FEAT] Create VO for share trading domain

### DIFF
--- a/src/main/java/org/bobj/order/domain/OrderBookVO.java
+++ b/src/main/java/org/bobj/order/domain/OrderBookVO.java
@@ -1,0 +1,26 @@
+package org.bobj.order.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderBookVO {
+    private Long orderId;
+    private Long userId;
+    private Long fundingId;
+    private OrderType orderType;                  // BUY or SELL
+    private BigDecimal orderPricePerShare;
+    private Integer orderShareCount;
+    private OrderStatus status;                   // PENDING / MATCHED / CANCELLED
+    private Integer remainingShareCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/bobj/order/domain/OrderStatus.java
+++ b/src/main/java/org/bobj/order/domain/OrderStatus.java
@@ -1,0 +1,7 @@
+package org.bobj.order.domain;
+
+public enum OrderStatus {
+    PENDING,
+    MATCHED,
+    CANCELLED
+}

--- a/src/main/java/org/bobj/order/domain/OrderType.java
+++ b/src/main/java/org/bobj/order/domain/OrderType.java
@@ -1,0 +1,5 @@
+package org.bobj.order.domain;
+
+public enum OrderType {
+    BUY, SELL
+}

--- a/src/main/java/org/bobj/share/domain/ShareVO.java
+++ b/src/main/java/org/bobj/share/domain/ShareVO.java
@@ -1,0 +1,19 @@
+package org.bobj.share.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShareVO {
+    private Long shareId;
+    private Long userId;
+    private Long fundingOrderId;
+    private Long fundingId;
+    private int shareCount;
+    private Long averageAmount;
+}

--- a/src/main/java/org/bobj/trade/domain/TradeRole.java
+++ b/src/main/java/org/bobj/trade/domain/TradeRole.java
@@ -1,0 +1,6 @@
+package org.bobj.trade.domain;
+
+public enum TradeRole {
+    BUYER,
+    SELLER
+}

--- a/src/main/java/org/bobj/trade/domain/TradeVO.java
+++ b/src/main/java/org/bobj/trade/domain/TradeVO.java
@@ -1,0 +1,24 @@
+package org.bobj.trade.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TradeVO {
+    private Long tradeId;
+    private Long orderId;
+    private Long shareId;
+    private Long userId;
+    private TradeRole tradeRole; // BUYER,SELLER
+    private Integer tradeCount;
+    private BigDecimal tradePricePerShare;
+    private LocalDateTime tradeDate;
+}


### PR DESCRIPTION
---
name: ✨ PR 템플릿
about: 새로운 기능 구현 및 추가를 위한 PR 템플릿입니다.
---
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
지분 거래 도메인을 구성하기 위한 VO(Value Object) 클래스를 생성하는 작업입니다.  
주요 테이블인 ORDER_BOOKS, SHARES, TRADES를 기반으로 각각의 도메인을 표현할 수 있는 VO를 구현하였습니다.

## 🔧 작업 내용

- OrderBook VO 생성  
  필드: orderId, userId, fundingId, orderType, orderPricePerShare, orderShareCount, status, remainingShareCount, createdAt, updatedAt  
  Enum: OrderType (BUY, SELL), OrderStatus (PENDING, MATCHED, CANCELLED)

- Share VO 생성  
  필드: shareId, userId, fundingOrderId (nullable), fundingId, shareCount, averageAmount

- Trade VO 생성  
  필드: tradeId, orderId, shareId, userId, tradeRole, tradeCount, tradePricePerShare, tradeDate  
  Enum: TradeRole (BUYER, SELLER)

- 폴더 구조 반영  
<img width="221" height="271" alt="image" src="https://github.com/user-attachments/assets/2416af79-f593-4ad4-af12-90346f494638" />


## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 추후 서비스 및 컨트롤러 계층에서 VO 활용 예정
- Enum 타입은 도메인 내 별도 파일로 관리

## 📎 관련 이슈
Close #6
