### PR TITLE
[FEAT] #1 Implement order placement, cancellation, and user order history retrieval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ ext {
     mybatisSpringVersion = '1.3.2'
     h2Version = '2.2.224'
     mysqlVersion = '8.1.0'
+    jacksonVersion = '2.13.5'
 }
 
 sourceCompatibility = '1.8'
@@ -76,7 +77,11 @@ dependencies {
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
     // Jackson - Json 처리
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+
 
 
 // xml내 한글 처리

--- a/src/main/java/org/bobj/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/bobj/common/exception/GlobalExceptionHandler.java
@@ -21,6 +21,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errorResponse);
     }
 
+    // IllegalStateException 처리 (400 Bad Request 또는 409 Conflict 등)
+    // 이 예외는 주로 비즈니스 로직의 '상태'가 유효하지 않을 때 발생합니다.
+    // OrderBookServiceImpl에서 던지는 IllegalStateException은 ErrorCode를 직접 사용하도록 변경할 것이므로,
+    // 여기서는 일반적인 IllegalStateException을 처리하는 용도로 남겨두거나,
+    // BusinessException을 도입하여 더 세분화할 수 있습니다.
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException ex, HttpServletRequest request) {
+          // 기본적으로 BAD_REQUEST로 처리하되, 특정 메시지에 따라 CONFLICT 등으로 변경할 수 있습니다.
+        // 예: if (ex.getMessage().contains("이미 체결된 주문입니다.")) return ResponseEntity.status(HttpStatus.CONFLICT).body(...);
+        ErrorResponse errorResponse = ErrorResponse.from(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
     // 그 외 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -6,6 +6,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -22,6 +23,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @PropertySource("classpath:/application.properties")
+@MapperScan(basePackages = {
+        "org.bobj.order.mapper",
+        "org.bobj.share.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
 @Import(SwaggerConfig.class)

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -9,9 +9,11 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
 @EnableWebMvc
-@ComponentScan(basePackages = {"org.example.controller"})  // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
+@ComponentScan(basePackages = {
+        "org.bobj.common.exception",
+        "org.bobj.controller",
+        "org.bobj.order.controller"})  // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
-
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/src/main/java/org/bobj/order/controller/OrderBookController.java
+++ b/src/main/java/org/bobj/order/controller/OrderBookController.java
@@ -1,0 +1,132 @@
+package org.bobj.order.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.common.exception.ErrorResponse;
+import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.order.dto.response.OrderBookResponseDTO;
+import org.bobj.order.service.OrderBookService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/order-books")
+@RequiredArgsConstructor
+@Log4j2
+@Api(tags="거래 주문 API")
+public class OrderBookController {
+
+    private final OrderBookService service;
+
+    @PostMapping("")
+    @ApiOperation(value = "거래 주문 등록", notes = "새로운 거래 주문 정보를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "거래 주문 성공", response = ApiCommonResponse.class),
+            @ApiResponse(code = 400, message = "잘못된 요청 (펀딩 미종료, 주식 미보유, 수량 부족, 발행량 초과 등)\n\n" +
+                    "**예시:**\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 400,\n" +
+                    "  \"code\": \"OB001\",\n" +
+                    "  \"message\": \"펀딩이 종료된 후에만 거래가 가능합니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 400,\n" +
+                    "  \"code\": \"OB002\",\n" +
+                    "  \"message\": \"해당 종목을 보유하고 있지 않습니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 400,\n" +
+                    "  \"code\": \"OB003\",\n" +
+                    "  \"message\": \"보유 주식 수량보다 많은 수량을 매도할 수 없습니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 400,\n" +
+                    "  \"code\": \"OB004\",\n" +
+                    "  \"message\": \"총 발행 주식 수를 초과하는 수량은 매수할 수 없습니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 400,\n" +
+                    "  \"code\": \"C001\",\n" +
+                    "  \"message\": \"잘못된 입력 값입니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```",
+                    response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "충돌 (예: 이미 체결된 주문)\n\n" +
+                    "**예시:**\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"status\": 409,\n" +
+                    "  \"code\": \"OB005\",\n" +
+                    "  \"message\": \"이미 체결된 주문입니다.\",\n" +
+                    "  \"path\": \"/api/v1/orders\"\n" +
+                    "}\n" +
+                    "```",
+                    response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public  ResponseEntity<ApiCommonResponse<OrderBookResponseDTO>> placeOrder(
+            @RequestBody @ApiParam(value = "거래 주문 DTO", required = true) org.bobj.order.dto.request.OrderBookRequestDTO dto) {
+
+        OrderBookResponseDTO created = service.placeOrder(dto);
+
+        ApiCommonResponse<OrderBookResponseDTO> response = ApiCommonResponse.createSuccess(created);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("history/{userId}")
+    @ApiOperation(value = "거래 주문 내역 조회", notes = "사용자의 거래 주문 내역을 조회합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "조회할 사용자 ID", required = false, dataType = "long", paramType = "path"),
+            @ApiImplicitParam(name = "orderType", value = "주문 타입 (BUY, SELL)", required = false, dataType = "string", paramType = "query")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "거래 주문 내역 조회 성공", response = OrderBookResponseDTO.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "잘못된 요청 (예: 유효하지 않은 파라미터)", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "조회된 주문 내역 없음", response = ErrorResponse.class), // 404는 보통 조회 결과가 없을 때 사용. 200 OK에 빈 리스트 반환이 일반적
+            @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<List<OrderBookResponseDTO>>> getOrderHistory(
+            @PathVariable Long userId,
+            @RequestParam(value = "orderType", required = false) String orderType
+    ) {
+        List<OrderBookResponseDTO> orderHistory = service.getOrderHistoryByUserId(userId, orderType);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(orderHistory));
+    }
+
+
+    @PatchMapping("/{orderId}")
+    @ApiOperation(value = "거래 주문 취소", notes = "주어진 주문 ID에 해당하는 거래 주문을 취소합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "orderId", value = "취소할 주문 ID", required = true, dataType = "long", paramType = "path")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "주문 취소 성공", response = ApiCommonResponse.class),
+            @ApiResponse(code = 400, message = "잘못된 요청 (예: 이미 취소된 주문)", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "해당 주문을 찾을 수 없음", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<String>> cancelOrder(@PathVariable Long orderId) {
+        service.cancelOrder(orderId);
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess("주문이 성공적으로 취소되었습니다."));
+    }
+}

--- a/src/main/java/org/bobj/order/dto/request/OrderBookRequestDTO.java
+++ b/src/main/java/org/bobj/order/dto/request/OrderBookRequestDTO.java
@@ -1,0 +1,45 @@
+package org.bobj.order.dto.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.bobj.order.domain.OrderBookVO;
+import org.bobj.order.domain.OrderType;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "거래 주문 등록 요청 DTO")
+public class OrderBookRequestDTO {
+
+    @ApiModelProperty(value = "사용자 ID", example = "1", required = true)
+    private Long userId;
+
+    @ApiModelProperty(value = "펀딩 ID", example = "1", required = true)
+    private Long fundingId;
+
+    @ApiModelProperty(value = "주문 타입", example = "BUY", allowableValues = "BUY, SELL", required = true)
+    private String orderType;
+
+    @ApiModelProperty(value = "주당 주문 가격", example = "15000.00", required = true)
+    private BigDecimal orderPricePerShare;
+
+    @ApiModelProperty(value = "주문 수량", example = "10", required = true)
+    private Integer orderShareCount;
+
+    public OrderBookVO toVo() {
+        return OrderBookVO.builder()
+                .userId(userId)
+                .fundingId(fundingId)
+                .orderType(OrderType.valueOf(orderType))
+                .orderPricePerShare(orderPricePerShare)
+                .orderShareCount(orderShareCount)
+                .build();
+    }
+}

--- a/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
+++ b/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
@@ -1,0 +1,68 @@
+package org.bobj.order.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.bobj.order.domain.OrderBookVO;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "거래 주문 응답 DTO")
+public class OrderBookResponseDTO {
+
+    @ApiModelProperty(value = "주문 ID", example = "1", required = false)
+    private Long orderId;
+
+    @ApiModelProperty(value = "사용자 ID", example = "1", required = true)
+    private Long userId;
+
+    @ApiModelProperty(value = "펀딩 ID", example = "1", required = true)
+    private Long fundingId;
+
+    @ApiModelProperty(value = "주문 타입 (BUY 또는 SELL)", example = "BUY", required = true, allowableValues = "BUY, SELL")
+    private String orderType;
+
+    @ApiModelProperty(value = "주당 주문 가격", example = "15000.00", required = true)
+    private BigDecimal orderPricePerShare;
+
+    @ApiModelProperty(value = "주문 수량", example = "10", required = true)
+    private Integer orderShareCount;
+
+    @ApiModelProperty(value = "주문 상태 (기본값: PENDING)", example = "PENDING", required = false, allowableValues = "PENDING, MATCHED, CANCELLED")
+    private String status;
+
+    @ApiModelProperty(value = "남은 수량", example = "10", required = false)
+    private Integer remainingShareCount;
+
+    @ApiModelProperty(value = "등록 일시", example = "2025-07-20T15:30:00", required = false)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @ApiModelProperty(value = "수정 일시", example = "2025-07-20T15:30:00", required = false)
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    public static OrderBookResponseDTO of(OrderBookVO vo){
+        return vo == null? null : OrderBookResponseDTO.builder()
+                .orderId(vo.getOrderId())
+                .userId(vo.getUserId())
+                .fundingId(vo.getFundingId())
+                .orderType(vo.getOrderType().name())
+                .orderPricePerShare(vo.getOrderPricePerShare())
+                .orderShareCount(vo.getOrderShareCount())
+                .status(vo.getStatus().name())
+                .remainingShareCount(vo.getRemainingShareCount())
+                .createdAt(vo.getCreatedAt())
+                .updatedAt(vo.getUpdatedAt())
+                .build();
+
+    }
+}

--- a/src/main/java/org/bobj/order/mapper/OrderBookMapper.java
+++ b/src/main/java/org/bobj/order/mapper/OrderBookMapper.java
@@ -1,0 +1,19 @@
+package org.bobj.order.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.bobj.order.domain.OrderBookVO;
+
+import java.util.List;
+
+public interface OrderBookMapper {
+
+    void create(OrderBookVO orderBookVO);
+
+    OrderBookVO get(Long orderId);
+
+    List<OrderBookVO> getOrderHistoryByUserId( @Param("userId") Long userId,
+                                               @Param("orderType") String orderType);
+    OrderBookVO getForUpdate(Long orderId);
+
+    void cancelOrder(Long orderId);
+}

--- a/src/main/java/org/bobj/order/service/OrderBookService.java
+++ b/src/main/java/org/bobj/order/service/OrderBookService.java
@@ -1,0 +1,18 @@
+package org.bobj.order.service;
+
+import org.bobj.order.dto.request.OrderBookRequestDTO;
+import org.bobj.order.dto.response.OrderBookResponseDTO;
+
+import java.util.List;
+
+
+public interface OrderBookService {
+
+    OrderBookResponseDTO getOrderById(Long orderId);
+
+    OrderBookResponseDTO placeOrder(OrderBookRequestDTO orderBookRequestDTO);
+
+    List<OrderBookResponseDTO> getOrderHistoryByUserId(Long userId, String orderType);
+
+    void cancelOrder(Long orderId);
+}

--- a/src/main/java/org/bobj/order/service/OrderBookServiceImpl.java
+++ b/src/main/java/org/bobj/order/service/OrderBookServiceImpl.java
@@ -1,0 +1,116 @@
+package org.bobj.order.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.order.domain.OrderBookVO;
+import org.bobj.order.domain.OrderStatus;
+import org.bobj.order.domain.OrderType;
+import org.bobj.order.dto.request.OrderBookRequestDTO;
+import org.bobj.order.dto.response.OrderBookResponseDTO;
+import org.bobj.order.mapper.OrderBookMapper;
+import org.bobj.share.mapper.ShareMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class OrderBookServiceImpl implements OrderBookService {
+
+    final private OrderBookMapper orderBookMapper;
+    final private ShareMapper shareMapper;
+//    final private TradeMapper tradeMapper;
+
+    @Override
+    public OrderBookResponseDTO getOrderById(Long orderId) {
+        OrderBookResponseDTO board =OrderBookResponseDTO.of(orderBookMapper.get(orderId));
+
+        return Optional.ofNullable(board).orElseThrow(NoSuchElementException::new);
+    }
+
+
+    @Transactional
+    @Override
+    public OrderBookResponseDTO placeOrder(OrderBookRequestDTO orderBookRequestDTO) {
+
+        OrderBookVO orderBookVO = orderBookRequestDTO.toVo();
+
+        // 1. 펀딩 상태 확인
+//        String fundingStatus = mapper.findFundingStatusByFundingId(orderBookVO.getFundingId());
+//        if (!"ENDED".equals(fundingStatus)) {
+//            throw new IllegalStateException("펀딩이 종료된 후에만 거래가 가능합니다.");
+//        }
+
+        // 2. 매도인일 경우 주식 보유 수량 확인
+        if ("SELL".equalsIgnoreCase(String.valueOf(orderBookVO.getOrderType()))) {
+            Integer userShareCount = shareMapper.findUserShareCount(orderBookVO.getUserId(), orderBookVO.getFundingId());
+
+            // 보유 수량이 없는 경우
+            if (userShareCount == null || userShareCount == 0) {
+                throw new IllegalStateException("해당 종목을 보유하고 있지 않습니다.");
+            }
+
+            // 수량은 있으나 매도 수량보다 적은 경우
+            if (userShareCount < orderBookVO.getOrderShareCount()) {
+                throw new IllegalArgumentException("보유 주식 수량보다 많은 수량을 매도할 수 없습니다.");
+            }
+        }
+
+        // 3. 매수인일 경우, 총 발행 주식 수보다 많은 수량을 주문하는 경우 체크
+//        if ("BUY".equals(orderBookVO.getOrderType())) {
+//            int totalIssuedShares = mapper.findTotalIssuedShares(orderBookVO.getFundingId());
+//            int totalBuyOrderCount = mapper.findTotalBuyOrderCount(orderBookVO.getFundingId());
+//            if (totalBuyOrderCount + orderBookVO.getOrderCount() > totalIssuedShares) {
+//                throw new IllegalArgumentException("총 발행 주식 수를 초과하는 수량은 매수할 수 없습니다.");
+//            }
+//        }
+//
+//        // 4. 중복 주문 방지
+//        boolean alreadyTraded = mapper.isOrderAlreadyTraded(orderBookVO);
+//        if (alreadyTraded) {
+//            throw new IllegalStateException("이미 체결된 주문입니다.");
+//        }
+
+
+        orderBookMapper.create(orderBookVO);
+
+        return getOrderById(orderBookVO.getOrderId());
+    }
+
+    @Override
+    public List<OrderBookResponseDTO> getOrderHistoryByUserId(Long userId, String orderTypeStr) {
+        OrderType orderType = null;
+
+        if (orderTypeStr != null && !orderTypeStr.trim().isEmpty()) {
+            try {
+                orderType = OrderType.valueOf(orderTypeStr.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("유효하지 않은 주문 타입입니다. (BUY 또는 SELL만 가능)");
+            }
+        }
+
+        List<OrderBookVO> orderBooks = orderBookMapper.getOrderHistoryByUserId(userId, orderType != null ? orderType.name() : null);
+        return orderBooks.stream().map(OrderBookResponseDTO::of).toList();
+    }
+
+    @Transactional
+    @Override
+    public void cancelOrder(Long orderId) {
+        OrderBookVO orderBook = orderBookMapper.getForUpdate(orderId);
+
+        if (orderBook.getStatus() == OrderStatus.MATCHED) {
+            throw new IllegalStateException("이미 체결된 주문은 취소할 수 없습니다.");
+        }
+
+        if (orderBook.getStatus() == OrderStatus.CANCELLED) {
+            throw new IllegalStateException("이미 취소된 주문입니다.");
+        }
+
+        orderBookMapper.cancelOrder(orderId);
+    }
+}

--- a/src/main/java/org/bobj/share/mapper/ShareMapper.java
+++ b/src/main/java/org/bobj/share/mapper/ShareMapper.java
@@ -1,0 +1,8 @@
+package org.bobj.share.mapper;
+
+import org.apache.ibatis.annotations.Param;
+
+public interface ShareMapper {
+    Integer findUserShareCount(@Param("userId") Long userId,
+                           @Param("fundingId") Long fundingId);
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
-  <!-- Appender, Layout 설정 -->
+<Configuration status="WARN">
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout charset="UTF-8" pattern=" %-5level %c(%M:%L) - %m%n"/>
+      <PatternLayout charset="UTF-8" pattern="%-5level %c(%M:%L) - %m%n"/>
     </Console>
   </Appenders>
-  <!-- Logger 설정 -->
+
   <Loggers>
+    <!-- 루트 로거 -->
     <Root level="INFO">
       <AppenderRef ref="console"/>
     </Root>
-    <Logger name="org.scoula" level="INFO" additivity="false" >
+
+    <!-- 스프링 프레임워크 로그 레벨 DEBUG로 올리기 -->
+    <Logger name="org.springframework" level="DEBUG" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
-    <Logger name="org.springframework" level="INFO" additivity="false">
+
+    <!-- MyBatis 로그 레벨 DEBUG로 올리기 -->
+    <Logger name="org.apache.ibatis" level="DEBUG" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+
+    <!-- MyBatis 관련 로깅(옵션) -->
+    <Logger name="org.mybatis" level="DEBUG" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
   </Loggers>

--- a/src/main/resources/org/bobj/order/mapper/OrderBookMapper.xml
+++ b/src/main/resources/org/bobj/order/mapper/OrderBookMapper.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.order.mapper.OrderBookMapper">
+
+    <insert id="create" parameterType="org.bobj.order.domain.OrderBookVO">
+        INSERT INTO order_books (
+            user_id,
+            funding_id,
+            order_type,
+            order_price_per_share,
+            order_share_count,
+            remaining_share_count
+        )
+        VALUES (
+                   #{userId},
+                   #{fundingId},
+                   #{orderType},
+                   #{orderPricePerShare},
+                   #{orderShareCount},
+                   #{orderShareCount}
+               )
+
+        <selectKey resultType="Long" keyProperty="orderId" keyColumn="order_id" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+
+    <select id="get" resultMap="orderBookMap">
+        SELECT *
+        FROM order_books
+        WHERE order_id = #{orderId}
+    </select>
+
+    <select id="getOrderHistoryByUserId" resultType="org.bobj.order.domain.OrderBookVO">
+        SELECT *
+        FROM order_books
+        WHERE user_id = #{userId}
+        <if test="orderType != null and orderType != ''">
+            AND order_type = #{orderType}
+        </if>
+        AND status IN ('PENDING', 'MATCHED')
+        ORDER BY created_at DESC
+    </select>
+
+    <select id="getForUpdate" resultType="org.bobj.order.domain.OrderBookVO">
+        SELECT *
+        FROM order_books
+        WHERE order_id = #{orderId}
+            FOR UPDATE
+    </select>
+
+    <update id="cancelOrder">
+        UPDATE order_books
+        SET
+            status = 'CANCELLED',
+            updated_at = NOW()
+        WHERE order_id = #{orderId}
+    </update>
+
+    <resultMap id="orderBookMap" type="org.bobj.order.domain.OrderBookVO">
+        <id property="orderId" column="order_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="fundingId" column="funding_id"/>
+        <result property="orderType" column="order_type"/>
+        <result property="orderPricePerShare" column="order_price_per_share"/>
+        <result property="orderShareCount" column="order_share_count"/>
+        <result property="status" column="status"/>
+        <result property="remainingShareCount" column="remaining_share_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+</mapper>

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.share.mapper.ShareMapper">
+
+    <select id="findUserShareCount" resultType="java.lang.Integer">
+        SELECT SUM(share_count)
+        FROM shares
+        WHERE user_id = #{userId}
+          AND funding_id = #{fundingId} FOR UPDATE
+    </select>
+</mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
- 거래 주문 기능의 기본 구현 완료: 주문 등록, 취소, 단일 조회, 사용자별 주문 내역 조회

## 🔧 작업 내용

- 매도 주문 등록 시 보유 주식 수량 체크 및 유효성 검증 추가
   -> 사용자가 실제 보유한 수량보다 많은 수량을 매도하려는 경우 예외 발생
- 주문 등록 시 `OrderType` 기반 유효성 검사
- 주문 등록 시 OrderType(BUY/SELL)에 따라 필요한 사전 조건 검증 구현
- 주문 상태(OrderStatus)에 따라 주문 취소 가능 여부 확인 로직 추가
 -> PENDING 상태일 경우만 취소 가능하도록 처리
- 사용자별 주문 내역 조회 API 구현
- OrderBookMapper.xml 쿼리 수정
   -> status 파라미터가 명시되지 않은 경우 기본적으로 PENDING, MATCHED 상태의 주문만 조회되도록 SQL 쿼리 조건 설정

## ✅ 체크리스트
- [x] Swagger UI에서 API 응답 정상 동작 확인

## 📝 기타 참고 사항
- 추후 `TradeMapper`와 매칭 로직 연동 예정 (주문 체결 처리)

## 📎 관련 이슈
Close #1
