### PR TITLE
feat: Implement trade matching logic

### DIFF
--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -26,7 +26,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @MapperScan(basePackages = {
         "org.bobj.order.mapper",
         "org.bobj.share.mapper",
-        "org.bobj.property.mapper"})
+        "org.bobj.property.mapper",
+        "org.bobj.trade.mapper",
+        "org.bobj.point.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
 @Import(SwaggerConfig.class)

--- a/src/main/java/org/bobj/order/domain/OrderBookVO.java
+++ b/src/main/java/org/bobj/order/domain/OrderBookVO.java
@@ -19,8 +19,9 @@ public class OrderBookVO {
     private OrderType orderType;                  // BUY or SELL
     private BigDecimal orderPricePerShare;
     private Integer orderShareCount;
-    private OrderStatus status;                   // PENDING / MATCHED / CANCELLED
+    private OrderStatus status;                   // 'PENDING', 'PARTIALLY_FILLED', 'FULLY_FILLED', 'CANCELLED'
     private Integer remainingShareCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private String propertyTitle;
 }

--- a/src/main/java/org/bobj/order/domain/OrderStatus.java
+++ b/src/main/java/org/bobj/order/domain/OrderStatus.java
@@ -1,7 +1,8 @@
 package org.bobj.order.domain;
 
 public enum OrderStatus {
-    PENDING,
-    MATCHED,
-    CANCELLED
+    PENDING,             // 주문만 등록된 상태 (체결 전)
+    PARTIALLY_FILLED,    // 일부 체결됨
+    FULLY_FILLED,        // 전량 체결됨 (기존 MATCHED)
+    CANCELLED            // 취소됨
 }

--- a/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
+++ b/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
@@ -27,6 +27,9 @@ public class OrderBookResponseDTO {
     @ApiModelProperty(value = "펀딩 ID", example = "1", required = true)
     private Long fundingId;
 
+    @ApiModelProperty(value = "건물 이름", example = "강남센트럴아이파크", required = false)
+    private String propertyTitle;
+
     @ApiModelProperty(value = "주문 타입 (BUY 또는 SELL)", example = "BUY", required = true, allowableValues = "BUY, SELL")
     private String orderType;
 
@@ -36,7 +39,7 @@ public class OrderBookResponseDTO {
     @ApiModelProperty(value = "주문 수량", example = "10", required = true)
     private Integer orderShareCount;
 
-    @ApiModelProperty(value = "주문 상태 (기본값: PENDING)", example = "PENDING", required = false, allowableValues = "PENDING, MATCHED, CANCELLED")
+    @ApiModelProperty(value = "주문 상태 (기본값: PENDING)", example = "PENDING", required = false, allowableValues = "PENDING,PARTIALLY_FILLED,FULLY_FILLED,CANCELLED")
     private String status;
 
     @ApiModelProperty(value = "남은 수량", example = "10", required = false)
@@ -55,6 +58,7 @@ public class OrderBookResponseDTO {
                 .orderId(vo.getOrderId())
                 .userId(vo.getUserId())
                 .fundingId(vo.getFundingId())
+                .propertyTitle(vo.getPropertyTitle())
                 .orderType(vo.getOrderType().name())
                 .orderPricePerShare(vo.getOrderPricePerShare())
                 .orderShareCount(vo.getOrderShareCount())

--- a/src/main/java/org/bobj/order/mapper/OrderBookMapper.java
+++ b/src/main/java/org/bobj/order/mapper/OrderBookMapper.java
@@ -2,7 +2,9 @@ package org.bobj.order.mapper;
 
 import org.apache.ibatis.annotations.Param;
 import org.bobj.order.domain.OrderBookVO;
+import org.bobj.order.domain.OrderStatus;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface OrderBookMapper {
@@ -16,4 +18,17 @@ public interface OrderBookMapper {
     OrderBookVO getForUpdate(Long orderId);
 
     void cancelOrder(Long orderId);
+
+    void updateOrderBookStatusAndRemainingCount(  //주문이 체결되거나 부분 체결될 때, 해당 주문의 남은 수량과 상태를 업데이트
+            @Param("orderId") Long orderId,
+            @Param("status") String status,
+            @Param("remainingShareCount") int remainingShareCount
+    );
+
+    List<OrderBookVO> findMatchingOrders(
+            @Param("fundingId") Long fundingId,
+            @Param("newOrderPrice") BigDecimal newOrderPrice,
+            @Param("oppositeOrderType") String oppositeOrderType,
+            @Param("newOrderType") String newOrderType
+    );
 }

--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -1,0 +1,201 @@
+package org.bobj.order.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.order.domain.OrderBookVO;
+import org.bobj.order.domain.OrderType;
+import org.bobj.order.mapper.OrderBookMapper;
+import org.bobj.point.domain.PointVO;
+import org.bobj.point.service.PointService;
+import org.bobj.share.domain.ShareVO;
+import org.bobj.share.mapper.ShareMapper;
+import org.bobj.trade.domain.TradeVO;
+import org.bobj.trade.mapper.TradeMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class OrderMatchingService {
+
+    private final OrderBookMapper orderBookMapper;
+    private final TradeMapper tradeMapper;
+    private final ShareMapper shareMapper;
+    private final PointService pointService;
+
+    @Transactional
+    public void processOrderMatching(OrderBookVO newOrder) {
+
+        // 1. 매칭될 반대편 주문 조회
+        // 신규 주문이 BUY 이면 SELL 주문을, SELL 이면 BUY 주문을 찾는다.
+        String oppositeOrderType = String.valueOf(newOrder.getOrderType() == OrderType.BUY
+                ? OrderType.SELL
+                : OrderType.BUY);
+
+        // 매칭 가능한 주문들을 조회
+        // 2. 대기 상태이면서, 같은 종목에 대한 반대 주문 리스트 가져오기
+        List<OrderBookVO> matchingOrders = orderBookMapper.findMatchingOrders(
+                newOrder.getFundingId(),
+                newOrder.getOrderPricePerShare(),
+                oppositeOrderType,
+                String.valueOf(newOrder.getOrderType())
+        );
+
+        // 3. 매칭 조건이 되는 주문과 체결 시도
+        int remainingNewOrderCount = newOrder.getOrderShareCount(); // 신규 주문의 남은 수량
+        BigDecimal tradePrice = newOrder.getOrderPricePerShare(); // 체결 가격
+
+        for (OrderBookVO matchedOrder : matchingOrders) {
+            if (remainingNewOrderCount <= 0) {
+                break;
+            }
+
+            // 2-1. 체결 가능한 수량 계산
+            int tradeCount = Math.min(remainingNewOrderCount, matchedOrder.getRemainingShareCount());
+
+            // 2-2. 체결 가격 결정
+            BigDecimal actualTradePrice = matchedOrder.getOrderPricePerShare(); // 상대방 주문 가격으로 체결
+
+            // 2-3. TRADES 테이블에 체결 내역 기록
+            Long buyOrderId = newOrder.getOrderType() == OrderType.BUY
+                    ? newOrder.getOrderId()
+                    : matchedOrder.getOrderId();
+
+            Long sellOrderId = newOrder.getOrderType() == OrderType.SELL
+                    ? newOrder.getOrderId()
+                    : matchedOrder.getOrderId();
+
+            Long buyerUserId = newOrder.getOrderType() == OrderType.BUY
+                    ? newOrder.getUserId()
+                    : matchedOrder.getUserId();
+
+            Long sellerUserId = newOrder.getOrderType() == OrderType.SELL
+                    ? newOrder.getUserId()
+                    : matchedOrder.getUserId();
+
+            TradeVO tradeVO = TradeVO.builder()
+                    .buyOrderId(buyOrderId)
+                    .sellOrderId(sellOrderId)
+                    .buyerUserId(buyerUserId)
+                    .sellerUserId(sellerUserId)
+                    .tradeCount(tradeCount)
+                    .tradePricePerShare(actualTradePrice)
+                    .build();
+
+            tradeMapper.insert(tradeVO);
+
+            // 2-4. OrderBook 업데이트 (신규 주문 및 매칭된 상대 주문)
+            // 신규 주문의 남은 수량 감소
+            remainingNewOrderCount -= tradeCount;
+            // 매칭된 상대 주문의 남은 수량 감소
+            int newMatchedOrderRemainingCount = matchedOrder.getRemainingShareCount() - tradeCount;
+
+            // 신규 주문 상태 업데이트
+            String newOrderStatus = (remainingNewOrderCount == 0) ? "FULLY_FILLED" : "PARTIALLY_FILLED";
+            orderBookMapper.updateOrderBookStatusAndRemainingCount(
+                    newOrder.getOrderId(),
+                    newOrderStatus,
+                    remainingNewOrderCount
+            );
+
+            // 매칭된 상대 주문 상태 업데이트
+            String matchedOrderStatus = (newMatchedOrderRemainingCount == 0) ? "FULLY_FILLED" : "PARTIALLY_FILLED";
+            orderBookMapper.updateOrderBookStatusAndRemainingCount(
+                    matchedOrder.getOrderId(),
+                    matchedOrderStatus,
+                    newMatchedOrderRemainingCount
+            );
+
+            // 2-5. 사용자 자산(주식 수량 및 포인트) 업데이트
+            //  매수자 포인트 업데이트
+            processBuyTradeAssets(buyerUserId, newOrder.getFundingId(), tradeCount, actualTradePrice);
+            // 매도자 포인트 업데이트
+            processSellTradeAssets(sellerUserId, newOrder.getFundingId(), tradeCount, actualTradePrice);
+        }
+    }
+
+    // 매수자 포인트 업데이트
+    private void processBuyTradeAssets(Long userId, Long fundingId, int tradedCount, BigDecimal actualTradePrice) {
+        // 1. 사용자 포인트 감소
+        BigDecimal totalTradeCost = actualTradePrice.multiply(new BigDecimal(tradedCount));
+
+        // 해당 user의 현재 PointVO를 조회 (락 필요)
+        PointVO userPoint = pointService.findByUserIdForUpdate(userId); // findByIdForUpdate, findByUserIdForUpdate 등 락 적용된 메서드 필요
+
+        if (userPoint.getAmount().compareTo(totalTradeCost) < 0) {
+            throw new IllegalStateException("매수자의 포인트가 부족합니다.");
+        }
+
+        userPoint.setAmount(userPoint.getAmount().subtract(totalTradeCost));
+        pointService.updatePoint(userPoint);
+
+        // 2. SHARES 테이블 업데이트
+        // 해당 사용자의 해당 펀딩에 대한 현재 보유 주식 정보 조회
+        ShareVO existingShare = shareMapper.findUserShareByFundingIdForUpdate(userId, fundingId);
+
+        if (existingShare == null) {
+            // 해당 종목을 처음 매수하는 경우: 새로운 SHARES 레코드 생성 (INSERT)
+            ShareVO newShare = ShareVO.builder()
+                    .userId(userId)
+                    .fundingId(fundingId)
+                    .shareCount(tradedCount)
+                    .averageAmount(actualTradePrice)
+                    .build();
+
+            shareMapper.insert(newShare);
+        } else {
+            // 이미 보유하고 있는 경우: 수량 증가 및 평균 단가 재계산 (UPDATE)
+            int newShareCount = existingShare.getShareCount() + tradedCount;
+
+            // 기존 총 매입 금액 = 기존 평균 단가 * 기존 보유 수량
+            BigDecimal existingTotalAmount = existingShare.getAverageAmount().multiply(new BigDecimal(existingShare.getShareCount()));
+            // 신규 매입 금액 = 현재 체결 가격 * 체결 수량
+            BigDecimal newTradeAmount = actualTradePrice.multiply(new BigDecimal(tradedCount));
+
+            // 새로운 총 매입 금액 = 기존 총 매입 금액 + 신규 매입 금액
+            BigDecimal combinedTotalAmount = existingTotalAmount.add(newTradeAmount);
+
+            // 새로운 평균 매입 단가 = 새로운 총 매입 금액 / 새로운 총 주식 수량
+            // DECIMAL(18, 4)에 맞춰 소수점 4자리까지 반올림
+            BigDecimal newAverageAmount = combinedTotalAmount.divide(new BigDecimal(newShareCount), 4, BigDecimal.ROUND_HALF_UP);
+
+            // SHARES 테이블 업데이트
+            shareMapper.update(existingShare.getShareId(), newShareCount, newAverageAmount);
+        }
+    }
+
+    // 매도자 포인트 업데이트
+    private void processSellTradeAssets(Long userId, Long fundingId, int tradedCount, BigDecimal actualTradePrice) {
+        // 1. 사용자 포인트 증가
+        BigDecimal totalTradeRevenue = actualTradePrice.multiply(new BigDecimal(tradedCount));
+
+        // 사용자 포인트 조회
+        PointVO userPoint = pointService.findByUserIdForUpdate(userId);
+
+        userPoint.setAmount(userPoint.getAmount().add(totalTradeRevenue));
+        pointService.updatePoint(userPoint);
+
+        // 2. SHARES 테이블 업데이트
+        // 사용자의 해당 펀딩에 대한 현재 보유 주식 정보 조회
+        ShareVO existingShare = shareMapper.findUserShareByFundingIdForUpdate(userId, fundingId); // 락 적용된 조회 메서드
+
+        // 주식을 보유하고 있는지 확인 (유효성 검사는 주문 접수 시점에서 이루어져야 하지만, 안전을 위해 다시 확인)
+        if (existingShare == null || existingShare.getShareCount() < tradedCount) {
+            throw new IllegalStateException("매도자의 주식 보유량이 부족하거나, 존재하지 않는 주식입니다.");
+        }
+
+        int newShareCount = existingShare.getShareCount() - tradedCount;
+
+        if (newShareCount == 0) {
+            // 모든 주식을 매도하여 보유량이 0이 된 경우: SHARES 레코드 삭제
+            shareMapper.delete(existingShare.getShareId());
+        } else {
+            // 일부 주식을 매도한 경우: 수량만 감소 (평균 단가는 매도 시 변하지 않음)
+            shareMapper.update(existingShare.getShareId(), newShareCount, existingShare.getAverageAmount());
+        }
+    }
+}

--- a/src/main/java/org/bobj/point/mapper/PointMapper.java
+++ b/src/main/java/org/bobj/point/mapper/PointMapper.java
@@ -17,4 +17,6 @@ public interface PointMapper {
     void update(PointVO point);
 
     void delete(@Param("pointId") Long pointId);
+
+    PointVO findByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/main/java/org/bobj/point/repository/PointRepository.java
+++ b/src/main/java/org/bobj/point/repository/PointRepository.java
@@ -33,4 +33,7 @@ public class PointRepository {
         pointMapper.delete(pointId);
     };
 
+    public PointVO findByUserIdForUpdate(Long userId){
+        return pointMapper.findByUserIdForUpdate(userId);
+    }
 }

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -32,6 +32,9 @@ public class PointService {
         pointRepository.delete(pointId);
     }
 
+    public PointVO findByUserIdForUpdate(Long userId){
+        return pointRepository.findByUserIdForUpdate(userId);
+    }
 
 
 }

--- a/src/main/java/org/bobj/share/domain/ShareVO.java
+++ b/src/main/java/org/bobj/share/domain/ShareVO.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -12,8 +15,9 @@ import lombok.NoArgsConstructor;
 public class ShareVO {
     private Long shareId;
     private Long userId;
-    private Long fundingOrderId;
     private Long fundingId;
     private int shareCount;
-    private Long averageAmount;
+    private BigDecimal averageAmount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/bobj/share/mapper/ShareMapper.java
+++ b/src/main/java/org/bobj/share/mapper/ShareMapper.java
@@ -1,8 +1,22 @@
 package org.bobj.share.mapper;
 
 import org.apache.ibatis.annotations.Param;
+import org.bobj.share.domain.ShareVO;
+
+import java.math.BigDecimal;
 
 public interface ShareMapper {
     Integer findUserShareCount(@Param("userId") Long userId,
-                           @Param("fundingId") Long fundingId);
+                               @Param("fundingId") Long fundingId);
+
+    void insert(ShareVO shareVO);
+
+    void update(@Param("shareId") Long shareId,
+                @Param("shareCount") int shareCount,
+                @Param("averageAmount") BigDecimal averageAmount);
+
+    void delete(@Param("shareId") Long shareId); // 또는 deleteShareByUserIdAndFundingId
+
+    ShareVO findUserShareByFundingIdForUpdate(@Param("userId") Long userId,
+                                              @Param("fundingId") Long fundingId);
 }

--- a/src/main/java/org/bobj/share/service/ShareService.java
+++ b/src/main/java/org/bobj/share/service/ShareService.java
@@ -1,0 +1,5 @@
+package org.bobj.share.service;
+
+
+public interface ShareService {
+}

--- a/src/main/java/org/bobj/share/service/ShareServiceImpl.java
+++ b/src/main/java/org/bobj/share/service/ShareServiceImpl.java
@@ -1,0 +1,11 @@
+package org.bobj.share.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ShareServiceImpl implements ShareService{
+}

--- a/src/main/java/org/bobj/trade/domain/TradeRole.java
+++ b/src/main/java/org/bobj/trade/domain/TradeRole.java
@@ -1,6 +1,0 @@
-package org.bobj.trade.domain;
-
-public enum TradeRole {
-    BUYER,
-    SELLER
-}

--- a/src/main/java/org/bobj/trade/domain/TradeVO.java
+++ b/src/main/java/org/bobj/trade/domain/TradeVO.java
@@ -14,11 +14,11 @@ import java.time.LocalDateTime;
 @Builder
 public class TradeVO {
     private Long tradeId;
-    private Long orderId;
-    private Long shareId;
-    private Long userId;
-    private TradeRole tradeRole; // BUYER,SELLER
+    private Long buyOrderId;
+    private Long sellOrderId;
+    private Long buyerUserId;
+    private Long sellerUserId;
     private Integer tradeCount;
     private BigDecimal tradePricePerShare;
-    private LocalDateTime tradeDate;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/org/bobj/trade/mapper/TradeMapper.java
+++ b/src/main/java/org/bobj/trade/mapper/TradeMapper.java
@@ -1,0 +1,10 @@
+package org.bobj.trade.mapper;
+
+import org.bobj.trade.domain.TradeVO;
+
+public interface TradeMapper {
+
+    // 체결 내역을 저장
+    void insert(TradeVO tradeVO);
+
+}

--- a/src/main/resources/org/bobj/order/mapper/OrderBookMapper.xml
+++ b/src/main/resources/org/bobj/order/mapper/OrderBookMapper.xml
@@ -4,6 +4,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.order.mapper.OrderBookMapper">
 
+    <!--주문 생성-->
     <insert id="create" parameterType="org.bobj.order.domain.OrderBookVO">
         INSERT INTO order_books (
             user_id,
@@ -27,20 +28,30 @@
         </selectKey>
     </insert>
 
+    <!-- 주문 단건 조회(orderId로) -->
     <select id="get" resultMap="orderBookMap">
         SELECT *
         FROM order_books
         WHERE order_id = #{orderId}
     </select>
 
+    <!-- 사용자별 주문 내역 조회-->
     <select id="getOrderHistoryByUserId" resultType="org.bobj.order.domain.OrderBookVO">
-        SELECT *
-        FROM order_books
-        WHERE user_id = #{userId}
+        SELECT
+            ob.*,
+            p.title AS propertyTitle
+        FROM
+            order_books ob
+        JOIN
+            fundings f ON ob.funding_id = f.funding_id  -- 주문 테이블과 펀딩 테이블 조인
+        JOIN
+            properties p ON f.property_id = p.property_id -- 펀딩 테이블과 매물 테이블 조인
+        WHERE
+            ob.user_id = #{userId}
         <if test="orderType != null and orderType != ''">
             AND order_type = #{orderType}
         </if>
-        AND status IN ('PENDING', 'MATCHED')
+--         AND status IN ('PENDING', 'PARTIALLY_FILLED','FULLY_FILLED')
         ORDER BY created_at DESC
     </select>
 
@@ -51,6 +62,7 @@
             FOR UPDATE
     </select>
 
+    <!--주문 취소-->
     <update id="cancelOrder">
         UPDATE order_books
         SET
@@ -58,6 +70,42 @@
             updated_at = NOW()
         WHERE order_id = #{orderId}
     </update>
+
+    <!-- 주문이 체결되거나 부분 체결될 때, 해당 주문의 남은 수량과 상태를 업데이트   -->
+    <update id="updateOrderBookStatusAndRemainingCount">
+        UPDATE ORDER_BOOKS
+        SET
+            status = #{status}, -- 'FULLY_FILLED', 'PARTIALLY_FILLED'
+            remaining_share_count = #{remainingShareCount},
+            updated_at = NOW()
+        WHERE
+            order_id = #{orderId}
+    </update>
+
+    <!-- 매칭 가능한 주문 조회-->
+    <select id="findMatchingOrders" resultType="org.bobj.order.domain.OrderBookVO">
+        SELECT *
+        FROM
+        ORDER_BOOKS
+        WHERE
+        funding_id = #{fundingId}
+        AND order_type = #{oppositeOrderType} -- 반대편 주문 타입 조회
+        AND (status = 'PENDING' OR status = 'PARTIALLY_FILLED')
+        <choose>
+            <when test="newOrderType == 'BUY'">
+                -- 신규 주문이 '매수'일 경우: 가장 낮은 '매도' 가격부터, 그리고 같은 가격이면 먼저 들어온 주문부터
+                AND order_price_per_share &lt;= #{newOrderPrice}
+                ORDER BY order_price_per_share ASC, created_at ASC
+            </when>
+            <otherwise>
+                -- 신규 주문이 '매도'일 경우: 가장 높은 '매수' 가격부터, 그리고 같은 가격이면 먼저 들어온 주문부터
+                AND order_price_per_share &gt;= #{newOrderPrice}
+                ORDER BY order_price_per_share DESC, created_at ASC
+            </otherwise>
+        </choose>
+        FOR UPDATE
+    </select>
+
 
     <resultMap id="orderBookMap" type="org.bobj.order.domain.OrderBookVO">
         <id property="orderId" column="order_id"/>

--- a/src/main/resources/org/bobj/point/mapper/PointMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointMapper.xml
@@ -14,6 +14,12 @@
     select * from point where user_id = #{userId};
   </select>
 
+  <select id="findByUserIdForUpdate" resultType="org.bobj.point.domain.PointVO">
+    select *
+    from point
+    where user_id = #{userId} FOR UPDATE;
+  </select>
+
   <insert id="insert" parameterType="PointVO">
     insert into point(user_id,amount,created_at) //db 칼럼
     VALUES (#{userId}, #{amount}, NOW())

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -4,10 +4,53 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.share.mapper.ShareMapper">
 
+    <!-- 펀딩 보유 주 삽입-->
+    <insert id="insert" parameterType="org.bobj.share.domain.ShareVO">
+        INSERT INTO SHARES (
+            user_id,
+            funding_id,
+            share_count,
+            average_amount
+        ) VALUES (
+                     #{userId},
+                     #{fundingId},
+                     #{shareCount},
+                     #{averageAmount}
+                 )
+        <selectKey keyProperty="shareId" resultType="long" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+
+    <!-- 펀딩 보유 주 수 업데이트-->
+    <update id="update">
+        UPDATE SHARES
+        SET
+            share_count = #{shareCount},
+            average_amount = #{averageAmount},
+            updated_at = NOW()
+        WHERE
+            share_id = #{shareId}
+    </update>
+
+    <!-- 사용자 펀딩 보유 주 수 가져오기-->
     <select id="findUserShareCount" resultType="java.lang.Integer">
         SELECT SUM(share_count)
-        FROM shares
+        FROM SHARES
         WHERE user_id = #{userId}
           AND funding_id = #{fundingId} FOR UPDATE
     </select>
+
+    <select id="findUserShareByFundingIdForUpdate" resultType="org.bobj.share.domain.ShareVO">
+        SELECT *
+        FROM SHARES
+        WHERE user_id = #{userId}
+          AND funding_id = #{fundingId} FOR UPDATE
+    </select>
+
+    <delete id="delete">
+        DELETE FROM SHARES
+        WHERE share_id = #{shareId}
+    </delete>
+
 </mapper>

--- a/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
+++ b/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.trade.mapper.TradeMapper">
+
+    <!--채결 내역 삽입-->
+    <insert id="insert" parameterType="org.bobj.trade.domain.TradeVO">
+        INSERT INTO TRADES (
+        buy_order_id,
+        sell_order_id,
+        buyer_user_id,
+        seller_user_id,
+        trade_count,
+        trade_price_per_share
+        ) VALUES (
+        #{buyOrderId},
+        #{sellOrderId},
+        #{buyerUserId},
+        #{sellerUserId},
+        #{tradeCount},
+        #{tradePricePerShare}
+        )
+        <selectKey resultType="Long" keyProperty="tradeId" keyColumn="trade_id" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+    </insert>
+</mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

거래 주문 시 자동으로 주문 매칭 및 체결이 이루어지는 **거래 체결 로직(Order Matching)** 을 구현하였습니다.
거래 체결 시 사용자들의 포인트 및 주식 보유량이 업데이트됩니다.

## 🔧 작업 내용
1. OrderMatchingService 구현
   : 새로운 주문이 접수될 때, 호가창에 있는 반대 주문(매칭될 수 있는)을 조회합니다.

    - 매칭 조건(가격, 수량)에 맞는 주문들을 찾아 체결을 시도합니다.
    - 체결된 주문에 따라 ORDER_BOOKS 테이블의 주문 상태(예: FULLY_FILLED, PARTIALLY_FILLED) 및 잔여 수량을 업데이트합니다.
    - TRADES 테이블에 체결 내역을 기록하도록 구현했습니다.

    - pocessBuyTradeAssets 메서드: 매수자의 자산(포인트 감소, 주식 증가)을 업데이트합니다.
          - 매수자의 포인트 잔액이 부족할 경우 예외를 발생시킵니다.
          - 해당 종목을 처음 매수하는 경우 SHARES 테이블에 새로운 레코드를 삽입하고, 이미 보유하고 있는 경우 주식 수량을 증가시키고 평균 단가를 재계산하여 업데이트합니다.
      
    - processSellTradeAssets 메서드: 매도자의 자산(포인트 증가, 주식 감소)을 업데이트합니다.
          - 매도자의 주식 보유량이 부족하거나 존재하지 않을 경우 예외를 발생시킵니다.
          - 해당 펀딩에 대한 모든 주식을 매도한 경우 SHARES 레코드를 삭제하고, 일부만 매도한 경우 주식 수량만 감소시킵니다.

2. OrderBookServiceImpl 업데이트
: 주문 등록(placeOrder) 시, 주문 저장 직후 OrderMatchingService.processOrderMatching()을 호출하여 즉시 체결을 시도하도록 로직을 추가했습니다.

3. 유효성 검사 및 예외 처리
- placeOrder 시 매도자가 주식을 보유하고 있는지, 매도 수량이 보유 수량을 초과하지 않는지 검증하는 로직을 포함했습니다.

- cancelOrder 시 이미 전량 체결되거나 취소된 주문인 경우 예외를 발생시킵니다.

## ✅ 체크리스트
- [x] 테스트 완료(Swagger) - 수동 테스트를 통해 주요 시나리오(성공적인 체결, 포인트 부족, 주식 부족, 부분 체결 등)를 검증했습니다.

## 📝 기타 참고 사항
- 매수/매도자가 동일할 경우, 체결 방지 로직은 아직 추가되지 않았습니다. 추후 보완 예정입니다.
- 일부 주석 처리된 로직(펀딩 상태 확인, 중복 주문 체크 등)은 향후 적용할 예정

## 📎 관련 이슈
Close #27 
