### PR TITLE
[FEAT] 사용자 지분 조회 API 구현

### DIFF
--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -13,7 +13,8 @@ import org.springframework.web.servlet.view.JstlView;
         "org.bobj.common.exception",
         "org.bobj.controller",
         "org.bobj.order.controller",
-        "org.bobj.property.controller"})
+        "org.bobj.property.controller",
+        "org.bobj.share.controller"})
 public class ServletConfig implements WebMvcConfigurer {
 
     @Override

--- a/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
+++ b/src/main/java/org/bobj/order/dto/response/OrderBookResponseDTO.java
@@ -67,6 +67,5 @@ public class OrderBookResponseDTO {
                 .createdAt(vo.getCreatedAt())
                 .updatedAt(vo.getUpdatedAt())
                 .build();
-
     }
 }

--- a/src/main/java/org/bobj/share/controller/ShareController.java
+++ b/src/main/java/org/bobj/share/controller/ShareController.java
@@ -1,0 +1,44 @@
+package org.bobj.share.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.common.exception.ErrorResponse;
+import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.share.dto.response.ShareResponseDTO;
+import org.bobj.share.service.ShareService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/shares")
+@RequiredArgsConstructor
+@Log4j2
+@Api(tags="지분 API")
+public class ShareController {
+    private final ShareService shareService;
+
+    @GetMapping("/users/{userId}") // 엔드포인트 정의
+    @ApiOperation(value = "사용자 보유 지분 조회", notes = "특정 사용자가 보유한 모든 주식 지분 정보를 조회합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "조회할 사용자 ID", required = true, dataType = "long", paramType = "path"),
+            @ApiImplicitParam(name = "page", value = "페이지 번호 (0부터 시작)", defaultValue = "0", dataType = "int", paramType = "query"),
+            @ApiImplicitParam(name = "size", value = "한 페이지당 항목 수", defaultValue = "10", dataType = "int", paramType = "query")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "사용자 보유 지분 조회 성공", response = ShareResponseDTO.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "잘못된 요청 (예: 유효하지 않은 사용자 ID)", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<List<ShareResponseDTO>>> getUserShares(
+            @PathVariable @ApiParam(value = "사용자 ID", required = true) Long userId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size
+    ) {
+        List<ShareResponseDTO> userShares = shareService.getSharesByUserIdPaging(userId, page, size);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(userShares));
+    }
+}

--- a/src/main/java/org/bobj/share/dto/response/ShareResponseDTO.java
+++ b/src/main/java/org/bobj/share/dto/response/ShareResponseDTO.java
@@ -1,0 +1,54 @@
+package org.bobj.share.dto.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.bobj.share.domain.ShareVO;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "지분 조회 응답 DTO")
+public class ShareResponseDTO {
+
+    @ApiModelProperty(value = "지분 ID", example = "1", required = true)
+    private Long shareId;
+
+    @ApiModelProperty(value = "사용자 ID", example = "1", required = true)
+    private Long userId;
+
+    @ApiModelProperty(value = "펀딩 ID", example = "1", required = true)
+    private Long fundingId;
+
+    @ApiModelProperty(value = "썸네일 URL", example = "http://example.com/property_photos/abc.jpg", required = false)
+    private String thumbnailUrl;
+
+    @ApiModelProperty(value = "건물 이름", example = "강남센트럴아이파크", required = true)
+    private String propertyTitle;
+
+    @ApiModelProperty(value = "현재 시세", example = "5550", required = true)
+    private BigDecimal currentShareAmount;
+
+    @ApiModelProperty(value = "주식 수량", example = "10", required = true)
+    private Integer shareCount;
+
+    @ApiModelProperty(value = "평단가", example = "5000", required = true)
+    private BigDecimal averageAmount;
+
+    public static ShareResponseDTO of(ShareVO shareVO) {
+        return ShareResponseDTO.builder()
+                .shareId(shareVO.getShareId())
+                .userId(shareVO.getUserId())
+                .fundingId(shareVO.getFundingId())
+                .shareCount(shareVO.getShareCount())
+                .averageAmount(shareVO.getAverageAmount())
+                .build();
+    }
+}

--- a/src/main/java/org/bobj/share/mapper/ShareMapper.java
+++ b/src/main/java/org/bobj/share/mapper/ShareMapper.java
@@ -2,8 +2,10 @@ package org.bobj.share.mapper;
 
 import org.apache.ibatis.annotations.Param;
 import org.bobj.share.domain.ShareVO;
+import org.bobj.share.dto.response.ShareResponseDTO;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public interface ShareMapper {
     Integer findUserShareCount(@Param("userId") Long userId,
@@ -19,4 +21,13 @@ public interface ShareMapper {
 
     ShareVO findUserShareByFundingIdForUpdate(@Param("userId") Long userId,
                                               @Param("fundingId") Long fundingId);
+
+    List<ShareResponseDTO> findSharesByUserId(@Param("userId") Long userId);
+
+    List<ShareResponseDTO> findSharesByUserIdPaging(@Param("userId") Long userId,
+                                                    @Param("offset") int offset,
+                                                    @Param("limit") int limit);
+
+    int countSharesByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/org/bobj/share/service/ShareService.java
+++ b/src/main/java/org/bobj/share/service/ShareService.java
@@ -1,5 +1,11 @@
 package org.bobj.share.service;
 
 
+import org.bobj.share.dto.response.ShareResponseDTO;
+
+import java.util.List;
+
 public interface ShareService {
+    List<ShareResponseDTO> getSharesByUserIdPaging(Long userId, int page, int size);
+    int getTotalSharesCount(Long userId); // 전체 개수 조회
 }

--- a/src/main/java/org/bobj/share/service/ShareServiceImpl.java
+++ b/src/main/java/org/bobj/share/service/ShareServiceImpl.java
@@ -2,10 +2,33 @@ package org.bobj.share.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.bobj.share.dto.response.ShareResponseDTO;
+import org.bobj.share.mapper.ShareMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 public class ShareServiceImpl implements ShareService{
+
+    private final ShareMapper shareMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ShareResponseDTO> getSharesByUserIdPaging(Long userId, int page, int size) {
+        if (page < 0) page = 0;
+        if (size <= 0) size = 10; // 페이지 크기가 0이하일 경우 기본값 설정
+
+        int offset = page * size;
+
+        return shareMapper.findSharesByUserIdPaging(userId, offset, size);
+    }
+
+    @Override
+    public int getTotalSharesCount(Long userId) {
+        return shareMapper.countSharesByUserId(userId);
+    }
 }

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -53,4 +53,80 @@
         WHERE share_id = #{shareId}
     </delete>
 
+    <!-- 사용자 모든 보유 주식 조회-->
+    <select id="findSharesByUserId" resultMap="shareResponseDTOMap">
+        SELECT
+            s.share_id AS s_share_id,
+            s.user_id AS s_user_id,
+            s.funding_id AS s_funding_id,
+            s.share_count AS s_share_count,
+            s.average_amount AS s_average_amount,
+            f.current_share_amount AS f_current_share_amount,
+            p.title AS p_title,
+            pp.photo_url AS thumbnail_url
+        FROM
+            shares s
+                JOIN
+            fundings f ON s.funding_id = f.funding_id
+                JOIN
+            properties p ON f.property_id = p.property_id
+                LEFT JOIN (
+                SELECT property_id, photo_url
+                FROM property_photos
+                WHERE (property_id, created_at) IN (
+                    SELECT property_id, MIN(created_at)
+                    FROM property_photos
+                    GROUP BY property_id
+                )
+            ) pp ON pp.property_id = p.property_id
+        WHERE
+            s.user_id = #{userId}
+    </select>
+
+    <select id="countSharesByUserId" resultType="java.lang.Integer">
+        SELECT
+            COUNT(s.share_id)
+        FROM
+            shares s
+        WHERE
+            s.user_id = #{userId}
+    </select>
+
+    <select id="findSharesByUserIdPaging" resultMap="shareResponseDTOMap">
+        SELECT
+            s.share_id AS s_share_id,
+            s.user_id AS s_user_id,
+            s.funding_id AS s_funding_id,
+            s.share_count AS s_share_count,
+            s.average_amount AS s_average_amount,
+            f.current_share_amount AS f_current_share_amount,
+            p.title AS p_title,
+            (SELECT photo_url
+             FROM property_photos pp
+             WHERE pp.property_id = p.property_id
+             ORDER BY created_at ASC
+                LIMIT 1) AS thumbnail_url
+        FROM
+            shares s
+            JOIN
+            fundings f ON s.funding_id = f.funding_id
+            JOIN
+            properties p ON f.property_id = p.property_id
+        WHERE
+            s.user_id = #{userId}
+        ORDER BY
+            s.share_id ASC  LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <resultMap id="shareResponseDTOMap" type="org.bobj.share.dto.response.ShareResponseDTO">
+        <id property="shareId" column="s_share_id"/>
+        <result property="userId" column="s_user_id"/>
+        <result property="fundingId" column="s_funding_id"/>
+        <result property="shareCount" column="s_share_count"/>
+        <result property="averageAmount" column="s_average_amount"/>
+        <result property="currentShareAmount" column="f_current_share_amount"/>
+        <result property="propertyTitle" column="p_title"/>
+        <result property="thumbnailUrl" column="thumbnail_url"/>
+    </resultMap>
+
 </mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

사용자가 보유한 주식 지분 정보를 조회하는 API를 개발했습니다. 
이 API는 사용자의 지분 정보뿐만 아니라, 해당 지분과 연결된 매물의 건물명, 현재 시세, 썸네일 URL 등의 상세 정보까지 페이징 처리하여 제공합니다.

## 🔧 작업 내용
- `GET /api/shares/users/{userId}` 
   : 특정 사용자가 보유한 주식 지분 정보를 조회할 수 있도록 구현했습니다. 

   : 경로 변수로 사용자 ID(`userId`)를 받으며, 쿼리 파라미터로는 페이지 번호(`page`), 페이지당 항목 수(`size`) 등의 페이징 요청 정보가 담긴 `PagingRequestDTO`를 받습니다. 

-  `ShareMapper`에 `findSharesByUserIdPaging` 메서드를 추가하여 `offset`과 `limit` 기반의 데이터베이스 페이징을 처리

- `ShareResponseDTO`는 지분 기본 정보(`shareId`, `userId`, `shareCount`, `averageAmount`), 매물 이름(`propertyTitle`), 현재 시세(`currentShareAmount`), 그리고 조회된 썸네일 URL(`thumbnailUrl`)을 포함합니다.

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #37
