### PR TITLE
[FEAT] #45 Add JWT authentication with OAuth2 and automatic token refresh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,17 @@ dependencies {
             { exclude group: 'commons-logging', module: 'commons-logging' }
     implementation "org.springframework:spring-webmvc:${springVersion}"
     implementation 'javax.inject:javax.inject:1'
+    // @Resource 어노테이션을 사용하기 위해 추가한 의존성
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // Spring Security
     implementation "org.springframework.security:spring-security-web:${springSecurityVersion}"
     implementation "org.springframework.security:spring-security-config:${springSecurityVersion}"
     implementation "org.springframework.security:spring-security-core:${springSecurityVersion}"
     implementation "org.springframework.security:spring-security-crypto:${springSecurityVersion}"
+
+    //Spring OAuth2
+    implementation "org.springframework.security:spring-security-oauth2-client:${springSecurityVersion}"
 
     // MyBatis
     implementation "org.mybatis:mybatis:${mybatisVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'war'
 }
 
-group 'org.example'
+group 'org.bobj'
 version '1.0-SNAPSHOT'
 
 repositories {
@@ -15,7 +15,7 @@ ext {
     springVersion = '5.3.37'
     lombokVersion = '1.18.30'
     springSecurityVersion = '5.8.13'
-    slf4jVersion = '1.7.36'         // ✅ SLF4J 낮추기
+    slf4jVersion = '1.7.36'
     logbackVersion = '1.2.11'
     mybatisVersion = '3.4.6'
     mybatisSpringVersion = '1.3.2'
@@ -24,8 +24,6 @@ ext {
     jacksonVersion = '2.13.5'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -79,7 +77,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.18.0'
     // Logging
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-    implementation "ch.qos.logback:logback-classic:${logbackVersion}"
+//    implementation "ch.qos.logback:logback-classic:${logbackVersion}"
 
 
     // Swagger

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ dependencies {
     //Spring OAuth2
     implementation "org.springframework.security:spring-security-oauth2-client:${springSecurityVersion}"
 
+    // JWT (JSON Web Token) 라이브러리
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // MyBatis
     implementation "org.mybatis:mybatis:${mybatisVersion}"
     implementation "org.mybatis:mybatis-spring:${mybatisSpringVersion}"
@@ -88,6 +93,10 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
 
+    // Jackson - json처리
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.6'
+
+
 
 // xml내 한글 처리
     implementation 'xerces:xercesImpl:2.12.2'
@@ -103,6 +112,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
     testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+
 
 
 

--- a/src/main/java/org/bobj/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/bobj/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ package org.bobj.common.exception;
 
 import javax.servlet.http.HttpServletRequest;
 import org.bobj.common.constants.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,11 +14,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
 
 
     // 일반 예외
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest requeset) {
+        log.error("IllegalArgumentException 발생: {}, URI: {}", ex.getMessage(), requeset.getRequestURI(), ex);
         ErrorResponse errorResponse = ErrorResponse.from(HttpStatus.BAD_REQUEST, ex.getMessage(), requeset.getRequestURI());
         return ResponseEntity.badRequest().body(errorResponse);
     }
@@ -37,6 +42,8 @@ public class GlobalExceptionHandler {
     // 그 외 모든 예외
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+        // 실제 예외 정보를 로그에 출력
+        log.error("예상치 못한 서버 오류 발생: {}, URI: {}", ex.getMessage(), request.getRequestURI(), ex);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }

--- a/src/main/java/org/bobj/config/AppConfig.java
+++ b/src/main/java/org/bobj/config/AppConfig.java
@@ -1,0 +1,37 @@
+package org.bobj.config;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 프로젝트 전반에서 사용될 공용 Bean들을 등록하는 설정 클래스
+ */
+@Configuration
+public class AppConfig {
+
+    /**
+     * 외부 API를 호출하기 위한 RestTemplate을 Bean으로 등록합니다.
+     * @return RestTemplate 객체
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+    /**
+     * JSON 데이터를 Java 객체로 변환하거나 그 반대의 작업을 수행하는 ObjectMapper를 Bean으로 등록합니다.
+     * LocalDateTime 등의 Java 8 날짜/시간 타입을 처리할 수 있도록 JavaTimeModule을 등록합니다.
+     * @return ObjectMapper 객체
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // Java 8 날짜/시간 타입 지원 모듈 등록
+        mapper.registerModule(new JavaTimeModule());
+        // 필요에 따라 timestamp 대신 ISO-8601 형식 출력 설정 가능
+        // mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/src/main/java/org/bobj/config/AppConfig.java
+++ b/src/main/java/org/bobj/config/AppConfig.java
@@ -12,25 +12,21 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class AppConfig {
 
-    /**
-     * 외부 API를 호출하기 위한 RestTemplate을 Bean으로 등록합니다.
-     * @return RestTemplate 객체
-     */
+    //외부 API를 호출하기 위한 RestTemplate을 Bean으로 등록. @return RestTemplate
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
-    /**
-     * JSON 데이터를 Java 객체로 변환하거나 그 반대의 작업을 수행하는 ObjectMapper를 Bean으로 등록합니다.
-     * LocalDateTime 등의 Java 8 날짜/시간 타입을 처리할 수 있도록 JavaTimeModule을 등록합니다.
-     * @return ObjectMapper 객체
-     */
+
+    //JSON 데이터, Java 객체 사이 변환 ObjectMapper를 Bean 등록.
+    //LocalDateTime 등의 Java 8 날짜/시간 타입을 처리 JavaTimeModule
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         // Java 8 날짜/시간 타입 지원 모듈 등록
         mapper.registerModule(new JavaTimeModule());
         // 필요에 따라 timestamp 대신 ISO-8601 형식 출력 설정 가능
+
         // mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return mapper;
     }

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -18,9 +18,9 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 
-@MapperScan(basePackages = {"org.bobj.user.mapper"})
 @Configuration
 @PropertySource("classpath:/application.properties")
+@MapperScan(basePackages = {"org.bobj.user.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @MapperScan(basePackages = {
         "org.bobj.order.mapper",

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -5,6 +5,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.bobj.user.config.OAuth2ClientConfig;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -20,7 +22,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 
-
+/**
+ * @MapperScan 어노테이션을 추가하여 MyBatis 매퍼 인터페이스를 스캔할 패키지를 지정합니다.
+ */
+@MapperScan(basePackages = {"org.bobj.user.mapper"})
 @Configuration
 @PropertySource("classpath:/application.properties")
 @ComponentScan(basePackages = "org.bobj")
@@ -32,7 +37,13 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         "org.bobj.point.mapper",})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
-@Import(SwaggerConfig.class)
+@Import({
+        AppConfig.class,
+        SwaggerConfig.class,
+        SecurityConfig.class,
+        OAuth2ClientConfig.class
+})
+
 public class RootConfig {
 
     @Bean
@@ -79,6 +90,9 @@ public class RootConfig {
         SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
         factory.setDataSource(dataSource());
         factory.setConfigLocation(applicationContext.getResource("classpath:/mybatis-config.xml"));
+        factory.setMapperLocations(
+                new PathMatchingResourcePatternResolver().getResources("classpath*:mappers/**/*.xml")
+        );
         return factory.getObject();
     }
 

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -11,20 +11,13 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.*;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 
-/**
- * @MapperScan 어노테이션을 추가하여 MyBatis 매퍼 인터페이스를 스캔할 패키지를 지정합니다.
- */
 @MapperScan(basePackages = {"org.bobj.user.mapper"})
 @Configuration
 @PropertySource("classpath:/application.properties")
@@ -39,8 +32,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @Import({
         AppConfig.class,
-        SwaggerConfig.class,
-        SecurityConfig.class,
         OAuth2ClientConfig.class
 })
 

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -23,12 +23,13 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @PropertySource("classpath:/application.properties")
+@ComponentScan(basePackages = "org.bobj")
 @MapperScan(basePackages = {
         "org.bobj.order.mapper",
         "org.bobj.share.mapper",
         "org.bobj.property.mapper",
         "org.bobj.trade.mapper",
-        "org.bobj.point.mapper"})
+        "org.bobj.point.mapper",})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
 @Import(SwaggerConfig.class)

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -20,14 +20,14 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @PropertySource("classpath:/application.properties")
-@MapperScan(basePackages = {"org.bobj.user.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @MapperScan(basePackages = {
         "org.bobj.order.mapper",
         "org.bobj.share.mapper",
         "org.bobj.property.mapper",
         "org.bobj.trade.mapper",
-        "org.bobj.point.mapper",})
+        "org.bobj.point.mapper",
+        "org.bobj.user.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
 @Import({

--- a/src/main/java/org/bobj/config/SecurityConfig.java
+++ b/src/main/java/org/bobj/config/SecurityConfig.java
@@ -1,0 +1,84 @@
+package org.bobj.config;
+
+import org.bobj.user.service.CustomOAuth2UserService;
+import org.bobj.user.security.JwtAuthenticationFilter;
+import org.bobj.user.security.JwtTokenProvider;
+import org.bobj.user.security.OAuth2LoginSuccessHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // JwtTokenProvider만 주입받습니다.
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors().configurationSource(corsConfigurationSource())
+                .and()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                // --- 👇 이 부분이 핵심입니다 ---
+                .authorizeRequests(authorize -> authorize
+                        .antMatchers(
+                                "/", "/error",
+                                "/api/auth/**", // 최종 회원가입 API 경로는 인증 없이 접근 허용
+                                "/api/user/**",
+                                "/login/oauth2/code/kakao", // 카카오 로그인 리다이렉트 경로
+                                "/swagger-ui.html", "/swagger-resources/**", "/v2/api-docs", "/webjars/**"
+                        ).permitAll()
+                        .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
+                )
+                // ----------------------------
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler())
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService())
+                        )
+                );
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+    // 필요한 서비스들을 Bean으로 등록합니다.
+    // 이 서비스들은 더 이상 DB(UserMapper)에 직접 접근하지 않습니다.
+    @Bean
+    public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
+        return new OAuth2LoginSuccessHandler(jwtTokenProvider);
+    }
+
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService() {
+        return new CustomOAuth2UserService();
+    }
+
+    // CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:8081");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
 @EnableWebMvc
+@ComponentScan(basePackages = {"org.bobj.controller"})  // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 @ComponentScan(basePackages = {
         "org.bobj.common.exception",
         "org.bobj.controller",

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -1,10 +1,13 @@
 package org.bobj.config;
 
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
@@ -15,7 +18,8 @@ import org.springframework.web.servlet.view.JstlView;
         "org.bobj.controller",
         "org.bobj.order.controller",
         "org.bobj.property.controller",
-        "org.bobj.share.controller"})
+        "org.bobj.share.controller",
+        "org.bobj.user.controller"})
 public class ServletConfig implements WebMvcConfigurer {
 
     @Override

--- a/src/main/java/org/bobj/config/WebConfig.java
+++ b/src/main/java/org/bobj/config/WebConfig.java
@@ -20,7 +20,8 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     protected Class<?>[] getServletConfigClasses() {
         return new Class[]{
             SwaggerConfig.class,
-            ServletConfig.class
+            ServletConfig.class,
+                SecurityConfig.class,
         };
     }
     // 스프링의 FrontController인 DispatcherServlet이 담당할 Url 매핑 패턴, / : 모든 요청에 대해 매핑

--- a/src/main/java/org/bobj/user/config/OAuth2ClientConfig.java
+++ b/src/main/java/org/bobj/user/config/OAuth2ClientConfig.java
@@ -1,0 +1,62 @@
+package org.bobj.user.config;
+
+//import org.apache.ibatis.mapping.Environment;
+import org.springframework.core.env.Environment;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+import javax.annotation.Resource;
+import java.util.Collections;
+
+/**
+ * OAuth2 클라이언트(카카오 등)의 등록 정보를 설정하는 클래스.
+ * non-Spring Boot 환경에서는 이처럼 수동으로 Bean을 등록해야 합니다.
+ */
+@Configuration
+@PropertySource("classpath:application.properties") // application.properties 파일의 내용을 읽어옵니다.
+public class OAuth2ClientConfig {
+
+    // @PropertySource로 읽어온 프로퍼티 값에 접근하기 위한 Environment 객체
+    @Resource
+    private Environment env;
+
+    /**
+     * OAuth2 클라이언트들의 정보를 담고 있는 저장소(Repository) Bean을 생성합니다.
+     * Spring Security는 이 Bean을 참조하여 사용할 OAuth2 클라이언트 정보를 찾습니다.
+     *
+     * @return 구성된 ClientRegistrationRepository 객체.
+     */
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+
+        // 1. 프로퍼티 파일에서 값들을 읽어옵니다.
+        String scope = env.getProperty("spring.security.oauth2.client.registration.kakao.scope");
+        String clientName = env.getProperty("spring.security.oauth2.client.registration.kakao.client-name");
+        String grantType = env.getProperty("spring.security.oauth2.client.registration.kakao.authorization-grant-type");
+
+        // 2. ClientRegistration 빌더를 사용하여 클라이언트 정보를 설정합니다.
+        ClientRegistration kakaoClientRegistration = ClientRegistration.withRegistrationId("kakao")
+                .clientId(env.getProperty("spring.security.oauth2.client.registration.kakao.client-id"))
+                .clientSecret(env.getProperty("spring.security.oauth2.client.registration.kakao.client-secret"))
+                // 3. 읽어온 값들을 사용하여 설정합니다.
+                .scope(scope.split(",")) // 쉼표로 구분된 문자열을 배열로 변환
+                .authorizationGrantType(new AuthorizationGrantType(grantType))
+                .clientName(clientName)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.POST)
+                .redirectUriTemplate(env.getProperty("spring.security.oauth2.client.registration.kakao.redirect-uri"))
+                .authorizationUri(env.getProperty("spring.security.oauth2.client.provider.kakao.authorization-uri"))
+                .tokenUri(env.getProperty("spring.security.oauth2.client.provider.kakao.token-uri"))
+                .userInfoUri(env.getProperty("spring.security.oauth2.client.provider.kakao.user-info-uri"))
+                .userNameAttributeName(env.getProperty("spring.security.oauth2.client.provider.kakao.user-name-attribute"))
+                .build();
+
+        return new InMemoryClientRegistrationRepository(Collections.singletonList(kakaoClientRegistration));
+    }
+}

--- a/src/main/java/org/bobj/user/config/SecurityWebAppInitializer.java
+++ b/src/main/java/org/bobj/user/config/SecurityWebAppInitializer.java
@@ -1,0 +1,13 @@
+package org.bobj.user.config;
+
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+
+/**
+ * Spring Security를 활성화하고 서블릿 컨테이너에 필터 체인을 등록하는 클래스입니다.
+ * 이 클래스를 추가하는 것만으로도 Spring Security가 동작하기 시작합니다.
+ */
+public class SecurityWebAppInitializer extends AbstractSecurityWebApplicationInitializer {
+    // 이 클래스는 특별한 내용을 작성할 필요가 없습니다.
+    // 생성자에서 로드할 설정 클래스를 지정할 수는 있지만,
+    // RootConfig에서 @Import로 관리하므로 비워둡니다.
+}

--- a/src/main/java/org/bobj/user/controller/AuthController.java
+++ b/src/main/java/org/bobj/user/controller/AuthController.java
@@ -1,0 +1,71 @@
+package org.bobj.user.controller;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.bobj.user.dto.AdditionalInfoDTO;
+import org.bobj.user.dto.TokenDTO;
+import org.bobj.user.security.JwtTokenProvider;
+import org.bobj.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth") // API 경로를 /api/auth로 통일하는 것을 권장합니다.
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/kakao-login-url")
+    public ResponseEntity<Map<String, String>> getKakaoLoginUrl() {
+        // Kakao OAuth2 인증 URL을 직접 작성
+        String kakaoLoginUrl = "http://localhost:8080/oauth2/authorization/kakao";
+        return ResponseEntity.ok(Collections.singletonMap("url", kakaoLoginUrl));
+    }
+
+    @GetMapping("/check-user")
+    public ResponseEntity<Map<String, Object>> checkUserExist(HttpServletRequest request) {
+        String token = jwtTokenProvider.resolveToken(request);
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            return ResponseEntity.status(401).body(Collections.singletonMap("error", "Invalid token"));
+        }
+
+        Claims claims = jwtTokenProvider.getClaims(token);
+        String email = claims.get("email", String.class);
+
+        boolean exists = userService.findUserInfoByEmail(email).isPresent();
+
+        // 토큰의 email 정보와 존재 여부를 함께 리턴
+        Map<String, Object> response = Map.of(
+                "exists", exists,
+                "email", email
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+
+//  @param additionalInfoDTO 사용자가 입력한 추가 정보 @param request HTTP 요청 객체 (Header에서 토큰을 읽기 위해 필요)@return 최종 토큰 DTO
+    @PostMapping("/register-final")
+    public ResponseEntity<TokenDTO> registerFinal(@RequestBody AdditionalInfoDTO additionalInfoDTO, HttpServletRequest request) {
+        // 1. Header에서 '사전 인증' 토큰을 추출합니다.
+        String preAuthToken = jwtTokenProvider.resolveToken(request);
+        if (preAuthToken == null || !jwtTokenProvider.validateToken(preAuthToken)) {
+            return ResponseEntity.status(401).body(null); // 유효하지 않은 토큰
+        }
+        // 2. 토큰에서 클레임(소셜 정보)을 추출합니다.
+        Claims claims = jwtTokenProvider.getClaims(preAuthToken);
+        if (!"pre-auth".equals(claims.get("type", String.class))) {
+            return ResponseEntity.status(403).body(null); // 토큰 타입이 올바르지 않음
+        }
+        // 3. UserService를 호출하여 최종 회원가입을 진행하고, 최종 토큰을 받습니다.
+        TokenDTO finalTokenDTO = userService.registerUserAndCreateFinalToken(additionalInfoDTO, claims);
+
+        return ResponseEntity.ok(finalTokenDTO);
+    }
+}

--- a/src/main/java/org/bobj/user/controller/AuthController.java
+++ b/src/main/java/org/bobj/user/controller/AuthController.java
@@ -2,70 +2,161 @@ package org.bobj.user.controller;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bobj.user.domain.UserVO;
 import org.bobj.user.dto.AdditionalInfoDTO;
 import org.bobj.user.dto.TokenDTO;
 import org.bobj.user.security.JwtTokenProvider;
 import org.bobj.user.service.UserService;
+import org.bobj.user.util.CookieUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.Map;
 
+@Slf4j
 @RestController
-@RequestMapping("/api/auth") // API 경로를 /api/auth로 통일하는 것을 권장합니다.
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @GetMapping("/kakao-login-url")
+    @GetMapping("/oauth/kakao-url")
     public ResponseEntity<Map<String, String>> getKakaoLoginUrl() {
-        // Kakao OAuth2 인증 URL을 직접 작성
         String kakaoLoginUrl = "http://localhost:8080/oauth2/authorization/kakao";
         return ResponseEntity.ok(Collections.singletonMap("url", kakaoLoginUrl));
     }
 
-    @GetMapping("/check-user")
-    public ResponseEntity<Map<String, Object>> checkUserExist(HttpServletRequest request) {
+    @GetMapping("/oauth/callback")
+    public ResponseEntity<?> checkUserExist(HttpServletRequest request, HttpServletResponse response) {
+        log.info("=== OAuth Callback 시작 ===");
+        
         String token = jwtTokenProvider.resolveToken(request);
         if (token == null || !jwtTokenProvider.validateToken(token)) {
+            log.warn("유효하지 않은 토큰으로 요청");
             return ResponseEntity.status(401).body(Collections.singletonMap("error", "Invalid token"));
         }
 
         Claims claims = jwtTokenProvider.getClaims(token);
-        String email = claims.get("email", String.class);
+        String email = claims.getSubject();
+        String provider = claims.get("provider", String.class);
+        String providerId = claims.get("providerId", String.class);
+        
+        log.info("토큰에서 추출한 정보 - email: {}, provider: {}, providerId: {}", email, provider, providerId);
 
-        boolean exists = userService.findUserInfoByEmail(email).isPresent();
+        try {
+            // 이메일로 사용자 존재 확인
+            log.info("이메일로 사용자 조회 시작: {}", email);
+            UserVO user = userService.findUserVOByEmail(email);
+            log.info("사용자 조회 성공 - userId: {}, nickname: {}", user.getUserId(), user.getNickname());
+            
+            // 소셜 로그인 정보도 함께 확인하고 기존 사용자 로그인 처리
+            log.info("소셜 로그인 처리 시작 - provider: {}, providerId: {}", provider, providerId);
+            TokenDTO tokenDTO = userService.loginExistingSocialUser(provider, providerId);
+            log.info("소셜 로그인 처리 성공 - 토큰 발급 완료");
 
-        // 토큰의 email 정보와 존재 여부를 함께 리턴
-        Map<String, Object> response = Map.of(
-                "exists", exists,
-                "email", email
-        );
+            // Access Token을 쿠키로 설정
+//            CookieUtil.setAccessTokenCookie(response, tokenDTO.getAccessToken());
 
-        return ResponseEntity.ok(response);
+            return ResponseEntity.ok(tokenDTO);
+        } catch (UsernameNotFoundException e) {
+            log.info("신규 사용자 감지 - email: {}", email);
+            return ResponseEntity.ok(Map.of(
+                    "exists", false,
+                    "email", email
+            ));
+        } catch (Exception e) {
+            log.error("OAuth Callback 처리 중 예외 발생 - email: {}, provider: {}, providerId: {}", 
+                email, provider, providerId, e);
+            throw e; // GlobalExceptionHandler가 처리하도록 다시 던짐
+        }
     }
 
-
-//  @param additionalInfoDTO 사용자가 입력한 추가 정보 @param request HTTP 요청 객체 (Header에서 토큰을 읽기 위해 필요)@return 최종 토큰 DTO
-    @PostMapping("/register-final")
-    public ResponseEntity<TokenDTO> registerFinal(@RequestBody AdditionalInfoDTO additionalInfoDTO, HttpServletRequest request) {
-        // 1. Header에서 '사전 인증' 토큰을 추출합니다.
+    @PostMapping("/signup/complete")
+    public ResponseEntity<TokenDTO> registerFinal(@RequestBody AdditionalInfoDTO additionalInfoDTO,
+                                                  HttpServletRequest request,
+                                                  HttpServletResponse response) {
         String preAuthToken = jwtTokenProvider.resolveToken(request);
         if (preAuthToken == null || !jwtTokenProvider.validateToken(preAuthToken)) {
-            return ResponseEntity.status(401).body(null); // 유효하지 않은 토큰
+            return ResponseEntity.status(401).body(null);
         }
-        // 2. 토큰에서 클레임(소셜 정보)을 추출합니다.
+
         Claims claims = jwtTokenProvider.getClaims(preAuthToken);
         if (!"pre-auth".equals(claims.get("type", String.class))) {
-            return ResponseEntity.status(403).body(null); // 토큰 타입이 올바르지 않음
+            return ResponseEntity.status(403).body(null);
         }
-        // 3. UserService를 호출하여 최종 회원가입을 진행하고, 최종 토큰을 받습니다.
+
         TokenDTO finalTokenDTO = userService.registerUserAndCreateFinalToken(additionalInfoDTO, claims);
+
+        // Access Token을 쿠키로 설정
+        CookieUtil.setAccessTokenCookie(response, finalTokenDTO.getAccessToken());
 
         return ResponseEntity.ok(finalTokenDTO);
     }
+
+    /**
+     * 로그아웃 - 쿠키 삭제 및 Refresh Token DB에서 제거
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getUserPk(token);
+            // Refresh Token DB에서 제거
+            userService.removeRefreshToken(email);
+        }
+
+        // 쿠키 삭제
+        CookieUtil.deleteAccessTokenCookie(response);
+
+        return ResponseEntity.ok(Collections.singletonMap("message", "로그아웃 되었습니다."));
+    }
+
+    /**
+     * Access Token 재발급
+     * 클라이언트는 만료된 Access Token만 보내고, 서버에서 DB의 Refresh Token으로 갱신
+     */
+    @PostMapping("/token/refresh")
+    public ResponseEntity<?> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        log.info("토큰 갱신 요청 시작");
+        
+        // 쿠키에서 만료된 access token 추출
+        String expiredAccessToken = jwtTokenProvider.resolveToken(request);
+        
+        if (expiredAccessToken == null) {
+            log.warn("토큰이 제공되지 않음");
+            return ResponseEntity.status(401).body(Collections.singletonMap("error", "No token provided"));
+        }
+        
+        // 만료된 토큰에서 사용자 정보 추출
+        String email = jwtTokenProvider.getUserEmailFromExpiredToken(expiredAccessToken);
+        if (email == null) {
+            log.warn("토큰에서 이메일 추출 실패");
+            return ResponseEntity.status(401).body(Collections.singletonMap("error", "Invalid token"));
+        }
+        
+        log.info("토큰 갱신 대상 사용자: {}", email);
+        
+        try {
+            // DB에서 해당 사용자의 refresh token으로 새 access token 발급
+            TokenDTO newTokenDTO = userService.refreshAccessTokenByEmail(email);
+            
+            // 새로운 Access Token을 쿠키로 설정
+            CookieUtil.setAccessTokenCookie(response, newTokenDTO.getAccessToken());
+            
+            log.info("토큰 갱신 완료: {}", email);
+            return ResponseEntity.ok(Collections.singletonMap("message", "Token refreshed successfully"));
+        } catch (Exception e) {
+            log.error("토큰 갱신 실패: {}, 이유: {}", email, e.getMessage());
+            return ResponseEntity.status(401).body(Collections.singletonMap("error", "Token refresh failed: " + e.getMessage()));
+        }
+    }
 }
+

--- a/src/main/java/org/bobj/user/controller/UserController.java
+++ b/src/main/java/org/bobj/user/controller/UserController.java
@@ -20,13 +20,13 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserResponseDTO> getMyInfo(@AuthenticationPrincipal User userDetails) {
         String userEmail = userDetails.getUsername();
-        UserResponseDTO myInfo = userService.getUserInfoByEmail(userEmail);
+        UserResponseDTO myInfo = userService.findUserInfoByEmail(userEmail);
         return ResponseEntity.ok(myInfo);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponseDTO> getUserInfo(@PathVariable Long userId) {
-        UserResponseDTO userInfo = userService.getUserInfo(userId);
+        UserResponseDTO userInfo = userService.findUserInfoById(userId);
         return ResponseEntity.ok(userInfo);
     }
 }

--- a/src/main/java/org/bobj/user/controller/UserController.java
+++ b/src/main/java/org/bobj/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package org.bobj.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.bobj.user.dto.UserResponseDTO;
+import org.bobj.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponseDTO> getMyInfo(@AuthenticationPrincipal User userDetails) {
+        String userEmail = userDetails.getUsername();
+        UserResponseDTO myInfo = userService.getUserInfoByEmail(userEmail);
+        return ResponseEntity.ok(myInfo);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponseDTO> getUserInfo(@PathVariable Long userId) {
+        UserResponseDTO userInfo = userService.getUserInfo(userId);
+        return ResponseEntity.ok(userInfo);
+    }
+}

--- a/src/main/java/org/bobj/user/domain/SocialLoginsVO.java
+++ b/src/main/java/org/bobj/user/domain/SocialLoginsVO.java
@@ -1,6 +1,7 @@
 package org.bobj.user.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,10 +16,18 @@ public class SocialLoginsVO {
     private Long userId;          // user_id BIGINT (FK)
     private String provider;      // provider VARCHAR(20) (e.g., "kakao", "naver")
     private String providerId;    // provider_id VARCHAR(255) (소셜 서비스의 고유 ID)
-    private String accessToken;   // access_token TEXT
     private String refreshToken;  // refresh_token TEXT
     private Date tokenExpiresAt;  // token_expires_at DATETIME
     private String profileData;   // profile_data JSON (JSON 문자열 그대로 저장)
     private Date createdAt;       // created_at DATETIME
 
+    @Builder
+    public SocialLoginsVO(Long userId, String provider, String providerId, String refreshToken, String profileData) {
+        this.userId = userId;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.refreshToken = refreshToken;
+        this.profileData = profileData;
+        this.createdAt = new Date();
+    }
 }

--- a/src/main/java/org/bobj/user/domain/SocialLoginsVO.java
+++ b/src/main/java/org/bobj/user/domain/SocialLoginsVO.java
@@ -17,7 +17,6 @@ public class SocialLoginsVO {
     private String provider;      // provider VARCHAR(20) (e.g., "kakao", "naver")
     private String providerId;    // provider_id VARCHAR(255) (소셜 서비스의 고유 ID)
     private String refreshToken;  // refresh_token TEXT
-    private Date tokenExpiresAt;  // token_expires_at DATETIME
     private String profileData;   // profile_data JSON (JSON 문자열 그대로 저장)
     private Date createdAt;       // created_at DATETIME
 

--- a/src/main/java/org/bobj/user/domain/UserVO.java
+++ b/src/main/java/org/bobj/user/domain/UserVO.java
@@ -1,20 +1,21 @@
 package org.bobj.user.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UsersVO {
+public class UserVO {
 
     private Long userId;          // user_id BIGINT
     private String name;          // name VARCHAR(100)
     private String email;         // email VARCHAR(255)
-    private String gender;        // gender CHAR(1)
     private String nickname;      // nickname VARCHAR(50)
     private String ssn;           // ssn VARCHAR(20) (주민등록번호)
     private String phone;         // phone VARCHAR(20)
@@ -23,5 +24,6 @@ public class UsersVO {
     private boolean isAdmin;      // is_admin BOOLEAN
     private String bankCode;      // bank_code VARCHAR(50)
     private String accountNumber; // account_number VARCHAR(50)
+
 
 }

--- a/src/main/java/org/bobj/user/domain/UserVO.java
+++ b/src/main/java/org/bobj/user/domain/UserVO.java
@@ -26,4 +26,7 @@ public class UserVO {
     private String accountNumber; // account_number VARCHAR(50)
 
 
+    public boolean getIsAdmin() {
+        return isAdmin;
+    }
 }

--- a/src/main/java/org/bobj/user/dto/AdditionalInfoDTO.java
+++ b/src/main/java/org/bobj/user/dto/AdditionalInfoDTO.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class AdditionalInfoDTO {
     private String name;
-    private String nickname;
     private String ssn;
     private String phone;
     private String bankCode;

--- a/src/main/java/org/bobj/user/dto/AdditionalInfoDTO.java
+++ b/src/main/java/org/bobj/user/dto/AdditionalInfoDTO.java
@@ -1,0 +1,18 @@
+// AdditionalInfoDTO.java
+package org.bobj.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class AdditionalInfoDTO {
+    private String name;
+    private String nickname;
+    private String ssn;
+    private String phone;
+    private String bankCode;
+    private String accountNumber;
+}

--- a/src/main/java/org/bobj/user/dto/TokenDTO.java
+++ b/src/main/java/org/bobj/user/dto/TokenDTO.java
@@ -1,0 +1,13 @@
+package org.bobj.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TokenDTO {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/org/bobj/user/dto/TokenDTO.java
+++ b/src/main/java/org/bobj/user/dto/TokenDTO.java
@@ -10,4 +10,13 @@ import lombok.Getter;
 public class TokenDTO {
     private String accessToken;
     private String refreshToken;
+    private Boolean isAdmin;    // 편의를 위해 유지
+    private String role;        // 추가
+
+    public TokenDTO(String accessToken, String refreshToken, boolean isAdmin) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.isAdmin = isAdmin;
+        this.role = isAdmin ? "ADMIN" : "USER";  // role 자동 설정
+    }
 }

--- a/src/main/java/org/bobj/user/dto/UserResponseDTO.java
+++ b/src/main/java/org/bobj/user/dto/UserResponseDTO.java
@@ -10,6 +10,10 @@ public class UserResponseDTO {
     private String email;
     private String nickname;
     private String phone;
+    private String accountNumber;
+    private String bankName;
+    private boolean isAdmin;    // 편의를 위해 유지
+    private String role;        // 추가
     // 필요한 다른 안전한 정보 추가
 
     public UserResponseDTO(UserVO user) {
@@ -18,5 +22,9 @@ public class UserResponseDTO {
         this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.phone = user.getPhone();
+        this.accountNumber = user.getAccountNumber();
+        this.bankName = user.getBankCode();
+        this.isAdmin = user.getIsAdmin();
+        this.role = user.getIsAdmin() ? "ADMIN" : "USER";  // role 자동 설정
     }
 }

--- a/src/main/java/org/bobj/user/dto/UserResponseDTO.java
+++ b/src/main/java/org/bobj/user/dto/UserResponseDTO.java
@@ -1,0 +1,22 @@
+package org.bobj.user.dto;
+
+import lombok.Getter;
+import org.bobj.user.domain.UserVO;
+
+@Getter
+public class UserResponseDTO {
+    private Long userId;
+    private String name;
+    private String email;
+    private String nickname;
+    private String phone;
+    // 필요한 다른 안전한 정보 추가
+
+    public UserResponseDTO(UserVO user) {
+        this.userId = user.getUserId();
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.phone = user.getPhone();
+    }
+}

--- a/src/main/java/org/bobj/user/mapper/UserMapper.java
+++ b/src/main/java/org/bobj/user/mapper/UserMapper.java
@@ -4,7 +4,6 @@ import org.bobj.user.domain.SocialLoginsVO;
 import org.bobj.user.domain.UserVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import java.util.Optional;
 
 @Mapper
 public interface UserMapper {

--- a/src/main/java/org/bobj/user/mapper/UserMapper.java
+++ b/src/main/java/org/bobj/user/mapper/UserMapper.java
@@ -10,13 +10,29 @@ import java.util.Optional;
 public interface UserMapper {
 
     // USERS 테이블 관련
-    Optional<UserVO> findUserByEmail(String email);
-    Optional<UserVO> findUserById(long userId);
+    UserVO findUserByEmail(String email);
+    UserVO findUserById(Long userId);
     void saveUser(UserVO user);
     void updateUser(UserVO user);
 
     // SOCIAL_LOGINS 테이블 관련
-    Optional<SocialLoginsVO> findSocialLoginByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
+    SocialLoginsVO findSocialLoginByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
     void saveSocialLogin(SocialLoginsVO socialLogin);
     void updateRefreshToken(SocialLoginsVO socialLogin);
+
+    /**
+     * Refresh Token으로 소셜 로그인 정보 조회
+     */
+    SocialLoginsVO findSocialLoginByRefreshToken(String refreshToken);
+
+    /**
+     * 특정 사용자의 Refresh Token 삭제 (로그아웃)
+     */
+    void clearRefreshTokenByUserId(Long userId);
+
+    /**
+     * 사용자 ID로 소셜 로그인 정보 조회 (토큰 갱신용)
+     */
+    SocialLoginsVO findSocialLoginByUserId(Long userId);
+
 }

--- a/src/main/java/org/bobj/user/mapper/UserMapper.java
+++ b/src/main/java/org/bobj/user/mapper/UserMapper.java
@@ -1,0 +1,22 @@
+package org.bobj.user.mapper;
+
+import org.bobj.user.domain.SocialLoginsVO;
+import org.bobj.user.domain.UserVO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.Optional;
+
+@Mapper
+public interface UserMapper {
+
+    // USERS 테이블 관련
+    Optional<UserVO> findUserByEmail(String email);
+    Optional<UserVO> findUserById(long userId);
+    void saveUser(UserVO user);
+    void updateUser(UserVO user);
+
+    // SOCIAL_LOGINS 테이블 관련
+    Optional<SocialLoginsVO> findSocialLoginByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
+    void saveSocialLogin(SocialLoginsVO socialLogin);
+    void updateRefreshToken(SocialLoginsVO socialLogin);
+}

--- a/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
@@ -1,6 +1,11 @@
 package org.bobj.user.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bobj.user.domain.SocialLoginsVO;
+import org.bobj.user.domain.UserVO;
+import org.bobj.user.service.UserService;
+import org.bobj.user.util.CookieUtil;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -12,37 +17,158 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String path = request.getRequestURI();
 
-        // 1. /api/auth/register-final 경로는 인증 필터 스킵
-        if (path.equals("/api/auth/register-final") || path.startsWith("/oauth2/")) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        log.debug("JWT Filter 처리: {} {}", method, path);
+
+        // 토큰 추출 (Authorization Header 또는 Cookie에서)
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token == null) {
+            // 토큰이 없는 경우는 Spring Security가 처리 (permitAll이면 통과, 아니면 401)
             filterChain.doFilter(request, response);
             return;
         }
 
-        // 2. 토큰 추출
-        String token = jwtTokenProvider.resolveToken(request);
-
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 3. 토큰 타입이 pre-auth 인지 확인
-            String tokenType = jwtTokenProvider.getClaims(token).get("type", String.class);
-
-            if (!"pre-auth".equals(tokenType)) {
-                // 일반 access 토큰이라면 인증 세팅
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 토큰 유효성 검사
+        if (jwtTokenProvider.validateToken(token)) {
+            // 정상 토큰 → 기존 로직
+            handleValidToken(token, path, response);
+        } else if (jwtTokenProvider.isTokenExpired(token)) {
+            // 만료된 토큰 → 자동 갱신 시도
+            String refreshedToken = attemptTokenRefresh(token, request, response);
+            if (refreshedToken != null) {
+                handleValidToken(refreshedToken, path, response);
+            } else {
+                // 갱신 실패 → 401 처리
+                log.warn("토큰 자동 갱신 실패: {}", path);
+                sendUnauthorizedResponse(response, "Token refresh failed");
+                return;
             }
-            // pre-auth 토큰이면 인증 컨텍스트 세팅 없이 통과
+        } else {
+            // 잘못된 토큰 → 401 처리
+            log.warn("유효하지 않은 토큰: {}", path);
+            sendUnauthorizedResponse(response, "Invalid token");
+            return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 유효한 토큰 처리
+     */
+    private void handleValidToken(String token, String path, HttpServletResponse response) throws IOException {
+        try {
+            String tokenType = jwtTokenProvider.getClaims(token).get("type", String.class);
+
+            if ("access".equals(tokenType)) {
+                // Access Token - 일반적인 API 인증
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Access Token 인증 성공: {}", authentication.getName());
+
+            } else if ("pre-auth".equals(tokenType)) {
+                // Pre-Auth Token - 특정 경로에서만 허용
+                if (isPreAuthAllowedPath(path)) {
+                    log.debug("Pre-Auth Token 허용 경로: {}", path);
+                    // 인증 컨텍스트는 설정하지 않고 통과
+                } else {
+                    log.warn("Pre-Auth Token 비허용 경로: {}", path);
+                    sendUnauthorizedResponse(response, "Pre-auth token not allowed for this endpoint");
+                    return;
+                }
+            } else {
+                log.warn("알 수 없는 토큰 타입: {}", tokenType);
+                sendUnauthorizedResponse(response, "Invalid token type");
+                return;
+            }
+
+        } catch (Exception e) {
+            log.error("토큰 처리 중 오류 발생", e);
+            sendUnauthorizedResponse(response, "Token processing error");
+            return;
+        }
+    }
+
+    /**
+     * 자동 토큰 갱신 시도
+     */
+    private String attemptTokenRefresh(String expiredToken, HttpServletRequest request, HttpServletResponse response) {
+        try {
+            log.info("Access Token 자동 갱신 시도");
+            
+            // 1. 만료된 토큰에서 이메일 추출
+            String email = jwtTokenProvider.getUserEmailFromExpiredToken(expiredToken);
+            if (email == null) {
+                log.warn("만료된 토큰에서 이메일 추출 실패");
+                return null;
+            }
+            
+            // 2. 사용자 정보 조회
+            UserVO user = userService.findUserVOByEmail(email);
+            if (user == null) {
+                log.warn("사용자를 찾을 수 없음: {}", email);
+                return null;
+            }
+            
+            // 3. 소셜 로그인 정보에서 Refresh Token 조회
+            SocialLoginsVO socialLogin = userService.findSocialLoginByUserId(user.getUserId());
+            if (socialLogin == null || socialLogin.getRefreshToken() == null) {
+                log.warn("Refresh Token을 찾을 수 없음: {}", email);
+                return null;
+            }
+            
+            // 4. Refresh Token 유효성 검증
+            if (!jwtTokenProvider.validateToken(socialLogin.getRefreshToken())) {
+                log.warn("Refresh Token이 만료됨: {}", email);
+                // Refresh Token도 만료된 경우 → 로그아웃 처리
+                userService.removeRefreshToken(email);
+                CookieUtil.deleteAccessTokenCookie(response);
+                return null;
+            }
+            
+            // 5. 새로운 Access Token 생성
+            String newAccessToken = jwtTokenProvider.createAccessToken(email, user.getIsAdmin());
+            
+            // 6. 쿠키에 새 Access Token 설정
+            CookieUtil.setAccessTokenCookie(response, newAccessToken);
+            
+            log.info("Access Token 자동 갱신 성공: {}", email);
+            return newAccessToken;
+            
+        } catch (Exception e) {
+            log.error("토큰 자동 갱신 중 예외 발생", e);
+            return null;
+        }
+    }
+
+    /**
+     * Pre-Auth 토큰이 허용되는 경로인지 확인
+     */
+    private boolean isPreAuthAllowedPath(String path) {
+        return "/api/auth/oauth/callback".equals(path) ||
+                "/api/auth/signup/complete".equals(path);
+    }
+
+    /**
+     * 401 Unauthorized 응답 전송
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(String.format("{\"error\":\"%s\"}", message));
     }
 }

--- a/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package org.bobj.user.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        // 1. /api/auth/register-final 경로는 인증 필터 스킵
+        if (path.equals("/api/auth/register-final") || path.startsWith("/oauth2/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. 토큰 추출
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 3. 토큰 타입이 pre-auth 인지 확인
+            String tokenType = jwtTokenProvider.getClaims(token).get("type", String.class);
+
+            if (!"pre-auth".equals(tokenType)) {
+                // 일반 access 토큰이라면 인증 세팅
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            // pre-auth 토큰이면 인증 컨텍스트 세팅 없이 통과
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/bobj/user/security/JwtTokenProvider.java
+++ b/src/main/java/org/bobj/user/security/JwtTokenProvider.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.Cookie;
@@ -213,13 +212,5 @@ public class JwtTokenProvider {
     public String getUserRole(String token) {
         Claims claims = getClaims(token);
         return claims.get("role", String.class);
-    }
-
-    /**
-     * 토큰에서 관리자 여부 확인 (role 기반)
-     */
-    public boolean isAdminFromToken(String token) {
-        String role = getUserRole(token);
-        return "ADMIN".equals(role);
     }
 }

--- a/src/main/java/org/bobj/user/security/JwtTokenProvider.java
+++ b/src/main/java/org/bobj/user/security/JwtTokenProvider.java
@@ -1,0 +1,141 @@
+package org.bobj.user.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@ControllerAdvice
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    // 토큰 유효시간 설정
+    private static final long PRE_AUTH_TOKEN_EXPIRE_TIME = 10 * 60 * 1000L;      // 10분 (사전 인증 임시 토큰)
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;      // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+
+    private Key key;
+    private final UserDetailsService userDetailsService;
+
+    @PostConstruct
+    protected void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /*** DB 저장 전, 소셜 로그인 정보만을 담는 임시 토큰을 생성합니다.
+     */
+    public String createPreAuthToken(String email, String nickname, String provider, String providerId) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("nickname", nickname);
+        claims.put("provider", provider);
+        claims.put("providerId", providerId);
+        claims.put("type", "pre-auth"); // 토큰 타입을 명시
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + PRE_AUTH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 최종 회원가입 완료 후, 사용자의 역할(Role) 정보를 포함하여 생성합니다.
+     */
+    public String createAccessToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("type", "access");
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성 메소드
+     */
+    public String createRefreshToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("type", "refresh");
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 최종 Access Token으로 Spring Security 인증 정보(Authentication)를 생성합니다.
+     * (이 메소드는 DB 조회를 포함합니다)
+     */
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    /**
+     * [신규] 토큰에서 모든 클레임(정보)을 추출합니다.
+     * 사전 인증 토큰의 정보를 읽을 때 사용됩니다.
+     */
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    /**
+     * 토큰에서 Subject(email)를 추출합니다.
+     */
+    public String getUserPk(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    /**
+     * Request의 Header에서 토큰 값을 가져옵니다. "Authorization" : "Bearer [TOKEN]"
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 토큰의 유효성 + 만료일자를 확인합니다.
+     */
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
@@ -53,7 +53,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
 
         // 프론트엔드로 이 임시 토큰을 전달합니다.
-        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8081/auth/callback")
+        String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUri) // 주입받은 값 사용
                 .queryParam("token", preAuthToken)
                 .queryParam("status", "PRE_AUTH")
                 .build().toUriString();

--- a/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package org.bobj.user.security;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -17,12 +18,15 @@ import java.util.Map;
 
 @Slf4j
 @Component
-@ControllerAdvice
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     // UserMapper 의존성을 제거합니다.
+
+    @Value("${custom.oauth2.redirect-uri}")
+    private String frontendRedirectUri;
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -51,7 +55,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         // 프론트엔드로 이 임시 토큰을 전달합니다.
         String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8081/auth/callback")
                 .queryParam("token", preAuthToken)
-                .queryParam("status", "PRE_AUTH") // 프론트엔드가 상태를 쉽게 파악하도록 쿼리 파라미터 추가
+                .queryParam("status", "PRE_AUTH")
                 .build().toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/bobj/user/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,59 @@
+package org.bobj.user.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@ControllerAdvice
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    // UserMapper 의존성을 제거합니다.
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공. '사전 인증' 임시 JWT 발급을 시작합니다.");
+
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // CustomOAuth2UserService에서 담아준 정보 추출
+        String provider = (String) attributes.get("provider");
+        String providerId = attributes.get("id").toString();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+        String nickname = ((Map<String, String>) kakaoAccount.get("profile")).get("nickname");
+
+        log.info("임시 JWT 생성을 위한 정보: email={}, nickname={}, provider={}, providerId={}", email, nickname, provider, providerId);
+
+        // DB 조회 없이, 소셜 정보만으로 '사전 인증' 상태의 임시 JWT를 생성합니다.
+        // 참고: 이 로직이 동작하려면 JwtTokenProvider에 createPreAuthToken 메소드가 필요합니다.
+        String preAuthToken = jwtTokenProvider.createPreAuthToken(email, nickname, provider, providerId);
+
+        log.info("사전 인증 토큰 생성 완료.");
+
+
+        // 프론트엔드로 이 임시 토큰을 전달합니다.
+        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8081/auth/callback")
+                .queryParam("token", preAuthToken)
+                .queryParam("status", "PRE_AUTH") // 프론트엔드가 상태를 쉽게 파악하도록 쿼리 파라미터 추가
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/org/bobj/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/bobj/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,57 @@
+package org.bobj.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    // 데이터베이스(UserMapper) 의존성을 완전히 제거합니다.
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService: DB 저장 없이 소셜 정보 처리 시작");
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // 카카오에서 받은 원본 속성들
+        Map<String, Object> originalAttributes = oAuth2User.getAttributes();
+
+        // SuccessHandler에서 사용할 수 있도록 새로운 속성 맵을 생성합니다.
+        Map<String, Object> customAttributes = new HashMap<>(originalAttributes);
+        customAttributes.put("provider", registrationId);
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) originalAttributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+
+        if (email == null) {
+            throw new OAuth2AuthenticationException("카카오 계정에서 이메일 정보를 가져올 수 없습니다. 동의 항목을 확인하세요.");
+        }
+
+        log.info("소셜 정보 확인 완료: email={}, provider={}", email, registrationId);
+
+        // DB를 거치지 않으므로, '사전 인증' 상태를 나타내는 임시 권한을 부여합니다.
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_PRE_AUTH")),
+                customAttributes,
+                userNameAttributeName);
+    }
+}

--- a/src/main/java/org/bobj/user/service/CustomUserDetailsService.java
+++ b/src/main/java/org/bobj/user/service/CustomUserDetailsService.java
@@ -21,7 +21,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         // userMapper의 결과가 null일 수 있으므로, Optional.ofNullable()로 안전하게 감싸줍니다.
         return Optional.ofNullable(userMapper.findUserByEmail(username))
-                .flatMap(optionalUser -> optionalUser) // 중첩된 Optional을 풀어줍니다.
                 .map(user -> new User(
                         user.getEmail(),
                         "", // JWT 방식에서는 비밀번호를 사용하지 않으므로 비워둡니다.

--- a/src/main/java/org/bobj/user/service/CustomUserDetailsService.java
+++ b/src/main/java/org/bobj/user/service/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package org.bobj.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.bobj.user.mapper.UserMapper;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // userMapper의 결과가 null일 수 있으므로, Optional.ofNullable()로 안전하게 감싸줍니다.
+        return Optional.ofNullable(userMapper.findUserByEmail(username))
+                .flatMap(optionalUser -> optionalUser) // 중첩된 Optional을 풀어줍니다.
+                .map(user -> new User(
+                        user.getEmail(),
+                        "", // JWT 방식에서는 비밀번호를 사용하지 않으므로 비워둡니다.
+                        Collections.emptyList() // 권한 설정 (필요 시 DB에서 조회하여 추가)
+                ))
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+    }
+}

--- a/src/main/java/org/bobj/user/service/UserService.java
+++ b/src/main/java/org/bobj/user/service/UserService.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -171,31 +170,6 @@ public class UserService {
         return user;
     }
 
-
-    /**
-     * Refresh Token으로 새로운 Access Token 발급
-     */
-    @Transactional
-    public TokenDTO refreshAccessToken(String refreshToken) {
-        Claims claims = jwtTokenProvider.getClaims(refreshToken);
-        String email = claims.getSubject();
-
-        // DB에서 저장된 Refresh Token과 비교
-        SocialLoginsVO socialLogin = userMapper.findSocialLoginByRefreshToken(refreshToken);
-        if (socialLogin == null) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
-        }
-
-        UserVO user = userMapper.findUserById(socialLogin.getUserId());
-        if (user == null) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다.");
-        }
-
-        // 새로운 Access Token 발급
-        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getIsAdmin());
-
-        return new TokenDTO(newAccessToken, refreshToken, user.getIsAdmin());
-    }
 
     /**
      * 이메일로 Refresh Token을 조회하여 새로운 Access Token 발급

--- a/src/main/java/org/bobj/user/service/UserService.java
+++ b/src/main/java/org/bobj/user/service/UserService.java
@@ -1,6 +1,5 @@
 package org.bobj.user.service;
 
-import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
@@ -13,15 +12,13 @@ import org.bobj.user.dto.TokenDTO;
 import org.bobj.user.dto.UserResponseDTO;
 import org.bobj.user.mapper.UserMapper;
 import org.bobj.user.security.JwtTokenProvider;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.Optional;
 
-@ControllerAdvice
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -29,92 +26,113 @@ public class UserService {
 
     private final UserMapper userMapper;
     private final JwtTokenProvider jwtTokenProvider;
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-    public UserResponseDTO getUserInfo(long userId) {
-        UserVO user = userMapper.findUserById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
-        return new UserResponseDTO(user);
-    }
-
-    public UserResponseDTO getUserInfoByEmail(String email) {
-        UserVO user = userMapper.findUserByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
-        return new UserResponseDTO(user);
-    }
+    private final ObjectMapper objectMapper;
 
     /**
-     * [로직 변경]
-     * 추가 정보와 '사전 인증 토큰'의 정보를 받아 DB에 최종 등록하고,
-     * 완전한 인증 토큰을 발급하는 메소드.
-     * @param dto 추가 정보 DTO
-     * @param preAuthClaims '사전 인증' 토큰에서 추출한 클레임 (email, nickname, provider, providerId 등)
-     * @return 최종 Access/Refresh 토큰 DTO
+     * AuthController에서 소셜 계정 존재 여부를 확인하기 위해 사용합니다.
      */
-    @Transactional
-    public TokenDTO registerUserAndCreateFinalToken(AdditionalInfoDTO dto, Claims preAuthClaims) {
-
-        try {
-            log.info("Pre-auth claims: {}", preAuthClaims);
-
-            log.info("최종 회원가입 및 토큰 발급 절차 시작");
-
-            // 1. 사전 인증 토큰에서 사용자 소셜 정보 추출
-//        String email = (String) preAuthClaims.get("email");
-            String email = (String) preAuthClaims.getSubject();
-            String provider = (String) preAuthClaims.get("provider");
-            String providerId = (String) preAuthClaims.get("providerId");
-
-            if (email == null || provider == null || providerId == null) {
-                throw new IllegalArgumentException("사전 인증 토큰의 정보가 올바르지 않습니다.");
-            }
-
-            // 2. DB에 이미 등록된 사용자인지 최종 확인
-            if (Optional.ofNullable(userMapper.findSocialLoginByProviderAndProviderId(provider, providerId))
-                    .orElse(Optional.empty()).isPresent()) {
-                throw new IllegalStateException("이미 등록된 소셜 계정입니다. 로그인 절차를 다시 시도해주세요.");
-            }
-
-            // 3. USERS 테이블에 사용자 저장
-            UserVO newUser = new UserVO();
-            newUser.setEmail(email);
-            newUser.setName(dto.getName());
-            newUser.setNickname(dto.getNickname()); // DTO에 닉네임 필드가 있다면 사용
-            newUser.setSsn(dto.getSsn());
-            newUser.setPhone(dto.getPhone());
-            newUser.setBankCode(dto.getBankCode());
-            newUser.setAccountNumber(dto.getAccountNumber());
-
-            userMapper.saveUser(newUser);
-            log.info("USERS 테이블에 신규 사용자 저장 완료. userId: {}", newUser.getUserId());
-
-            // 4. SOCIAL_LOGINS 테이블에 소셜 정보 저장
-            saveNewSocialLogin(newUser.getUserId(), provider, providerId, preAuthClaims);
-
-            // 5. 최종 인증 토큰 (Access/Refresh) 생성
-            String finalAccessToken = jwtTokenProvider.createAccessToken(newUser.getEmail());
-            String finalRefreshToken = jwtTokenProvider.createRefreshToken(newUser.getEmail());
-
-            // 리프레시 토큰을 DB에 저장하는 로직
-
-            log.info("최종 인증 토큰 발급 완료. email: {}", newUser.getEmail());
-            return new TokenDTO(finalAccessToken, finalRefreshToken);
-        } catch (Exception e) {
-            log.error("회원가입 및 토큰 발급 중 오류 발생", e);
-            throw e; // 필요시 커스텀 예외로 감싸도 됨
+    public Optional<SocialLoginsVO> findSocialLoginByProviderAndProviderId(String provider, String providerId) {
+        log.debug("소셜 로그인 정보 조회: provider={}, providerId={}", provider, providerId);
+        
+        // UserMapper에서 null을 반환할 수 있으므로 Optional로 감싸기
+        SocialLoginsVO result = userMapper.findSocialLoginByProviderAndProviderId(provider, providerId);
+        
+        if (result != null) {
+            log.debug("소셜 로그인 정보 조회 성공: userId={}", result.getUserId());
+            return Optional.of(result);
+        } else {
+            log.debug("소셜 로그인 정보를 찾을 수 없음: provider={}, providerId={}", provider, providerId);
+            return Optional.empty();
         }
     }
 
-//    @Transactional
-//    public TokenDTO registerUserAndCreateFinalToken(AdditionalInfoDTO dto, Claims claims) {
-//        // Claims는 Map<String, Object>를 상속해서 직접 변환 가능
-//        return registerUserAndCreateFinalToken(dto, (Map<String, Object>) claims);
-//        // 만약 형변환 문제 있으면 아래처럼 복사해서 전달 가능
-//        // return registerUserAndCreateFinalToken(dto, new HashMap<>(claims));
-//    }
+    /**
+     * 기존 소셜 계정 사용자의 로그인을 처리하고 최종 토큰을 발급합니다.
+     */
+    @Transactional
+    public TokenDTO loginExistingSocialUser(String provider, String providerId) {
+        log.info("기존 소셜 계정 로그인 처리 시작: provider={}, providerId={}", provider, providerId);
 
-    private void saveNewSocialLogin(Long userId, String provider, String providerId, Map<String, Object> attributes) {
         try {
+            log.info("소셜 로그인 정보 조회 시작: provider={}, providerId={}", provider, providerId);
+            SocialLoginsVO socialLogin = findSocialLoginByProviderAndProviderId(provider, providerId)
+                    .orElseThrow(() -> new IllegalStateException("해당 소셜 계정으로 등록된 사용자가 없습니다."));
+            log.info("소셜 로그인 정보 조회 성공: socialId={}, userId={}", socialLogin.getSocialId(), socialLogin.getUserId());
+
+            log.info("사용자 정보 조회 시작: userId={}", socialLogin.getUserId());
+            UserVO user = userMapper.findUserById(socialLogin.getUserId());
+            if (user == null) {
+                throw new IllegalStateException("연결된 사용자 계정을 찾을 수 없습니다.");
+            }
+            log.info("사용자 정보 조회 성공: email={}, nickname={}", user.getEmail(), user.getNickname());
+
+            // isAdmin 정보를 AccessToken 생성 시 넘김
+            log.info("JWT 토큰 생성 시작: email={}, isAdmin={}", user.getEmail(), user.getIsAdmin());
+            String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getIsAdmin());
+            String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+            log.info("JWT 토큰 생성 성공");
+
+            log.info("Refresh Token DB 저장 시작");
+            socialLogin.setRefreshToken(refreshToken);
+            userMapper.updateRefreshToken(socialLogin);
+            log.info("Refresh Token DB 저장 완료. userId: {}", user.getUserId());
+
+            log.info("기존 소셜 계정 로그인 처리 완료");
+            return new TokenDTO(accessToken, refreshToken, user.getIsAdmin());
+        } catch (Exception e) {
+            log.error("기존 소셜 계정 로그인 처리 중 예외 발생: provider={}, providerId={}", provider, providerId, e);
+            throw e;
+        }
+    }
+
+    /**
+     * 추가 정보와 '사전 인증 토큰'의 정보를 받아 DB에 최종 등록하고,
+     * 완전한 인증 토큰을 발급하는 메소드.
+     */
+    @Transactional
+    public TokenDTO registerUserAndCreateFinalToken(AdditionalInfoDTO dto, Claims preAuthClaims) {
+        log.info("최종 회원가입 및 토큰 발급 절차 시작");
+
+        String email = preAuthClaims.getSubject();
+        String provider = preAuthClaims.get("provider", String.class);
+        String providerId = preAuthClaims.get("providerId", String.class);
+        String kakaoNickname = preAuthClaims.get("nickname", String.class); // 카카오 닉네임 추출
+
+        if (email == null || provider == null || providerId == null) {
+            throw new IllegalArgumentException("사전 인증 토큰의 정보가 올바르지 않습니다.");
+        }
+
+        if (findSocialLoginByProviderAndProviderId(provider, providerId).isPresent()) {
+            throw new IllegalStateException("이미 등록된 소셜 계정입니다. 로그인 절차를 다시 시도해주세요.");
+        }
+
+        UserVO newUser = new UserVO();
+        newUser.setEmail(email);
+        newUser.setName(dto.getName());
+        newUser.setNickname(kakaoNickname); // 카카오에서 받은 닉네임 설정
+        newUser.setSsn(dto.getSsn());
+        newUser.setPhone(dto.getPhone());
+        newUser.setBankCode(dto.getBankCode());
+        newUser.setAccountNumber(dto.getAccountNumber());
+
+        userMapper.saveUser(newUser);
+        log.info("USERS 테이블에 신규 사용자 저장 완료. userId: {}", newUser.getUserId());
+
+        saveNewSocialLogin(newUser.getUserId(), provider, providerId, preAuthClaims);
+
+        String finalAccessToken = jwtTokenProvider.createAccessToken(newUser.getEmail(), newUser.getIsAdmin());
+        String finalRefreshToken = jwtTokenProvider.createRefreshToken(newUser.getEmail());
+        // (선택) 발급된 Refresh Token을 DB에 바로 저장
+        SocialLoginsVO savedSocialLogin = findSocialLoginByProviderAndProviderId(provider, providerId).get();
+        savedSocialLogin.setRefreshToken(finalRefreshToken);
+        userMapper.updateRefreshToken(savedSocialLogin);
+
+        log.info("최종 인증 토큰 발급 완료. email: {}", newUser.getEmail());
+        return new TokenDTO(finalAccessToken, finalRefreshToken, newUser.getIsAdmin());    }
+
+    private void saveNewSocialLogin(Long userId, String provider, String providerId, Claims attributes) {
+        try {
+            // Claims 객체는 Map과 호환되므로 직접 변환할 수 있습니다.
             String profileDataJson = objectMapper.writeValueAsString(attributes);
             SocialLoginsVO newSocialLogin = SocialLoginsVO.builder()
                     .userId(userId)
@@ -129,15 +147,107 @@ public class UserService {
         }
     }
 
-
-    public Optional<UserResponseDTO> findUserInfoByEmail(String email) {
-        return userMapper.findUserByEmail(email).map(UserResponseDTO::new);
+    public UserResponseDTO findUserInfoByEmail(String email) {
+        UserVO user = userMapper.findUserByEmail(email);
+        if (user == null) {
+            throw new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다.");
+        }
+        return new UserResponseDTO(user);
     }
 
-    public Optional<UserResponseDTO> findUserInfoById(Long userId) {
-        return userMapper.findUserById(userId).map(UserResponseDTO::new);
+    public UserResponseDTO findUserInfoById(Long userId) {
+        UserVO user = userMapper.findUserById(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("해당 ID의 사용자를 찾을 수 없습니다.");
+        }
+        return new UserResponseDTO(user);
+    }
+
+    public UserVO findUserVOByEmail(String email) {
+        UserVO user = userMapper.findUserByEmail(email);
+        if (user == null) {
+            throw new UsernameNotFoundException("유저를 찾을 수 없습니다: " + email);
+        }
+        return user;
     }
 
 
+    /**
+     * Refresh Token으로 새로운 Access Token 발급
+     */
+    @Transactional
+    public TokenDTO refreshAccessToken(String refreshToken) {
+        Claims claims = jwtTokenProvider.getClaims(refreshToken);
+        String email = claims.getSubject();
+
+        // DB에서 저장된 Refresh Token과 비교
+        SocialLoginsVO socialLogin = userMapper.findSocialLoginByRefreshToken(refreshToken);
+        if (socialLogin == null) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        UserVO user = userMapper.findUserById(socialLogin.getUserId());
+        if (user == null) {
+            throw new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+        }
+
+        // 새로운 Access Token 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getIsAdmin());
+
+        return new TokenDTO(newAccessToken, refreshToken, user.getIsAdmin());
+    }
+
+    /**
+     * 이메일로 Refresh Token을 조회하여 새로운 Access Token 발급
+     * 클라이언트가 Refresh Token을 모르는 경우 사용
+     */
+    @Transactional
+    public TokenDTO refreshAccessTokenByEmail(String email) {
+        log.info("이메일로 토큰 갱신 시도: {}", email);
+        
+        // 사용자 정보 조회
+        UserVO user = userMapper.findUserByEmail(email);
+        if (user == null) {
+            throw new IllegalArgumentException("사용자를 찾을 수 없습니다: " + email);
+        }
+        
+        // 소셜 로그인 정보에서 Refresh Token 조회
+        SocialLoginsVO socialLogin = userMapper.findSocialLoginByUserId(user.getUserId());
+        if (socialLogin == null || socialLogin.getRefreshToken() == null) {
+            throw new IllegalArgumentException("Refresh Token을 찾을 수 없습니다: " + email);
+        }
+        
+        // Refresh Token 유효성 검증
+        if (!jwtTokenProvider.validateToken(socialLogin.getRefreshToken())) {
+            log.warn("Refresh Token이 만료됨: {}", email);
+            // 만료된 Refresh Token 제거
+            removeRefreshToken(email);
+            throw new IllegalArgumentException("Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
+        }
+        
+        // 새로운 Access Token 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getIsAdmin());
+        
+        log.info("토큰 갱신 성공: {}", email);
+        return new TokenDTO(newAccessToken, socialLogin.getRefreshToken(), user.getIsAdmin());
+    }
+
+    /**
+     * 로그아웃 시 Refresh Token 제거
+     */
+    @Transactional
+    public void removeRefreshToken(String email) {
+        UserVO user = userMapper.findUserByEmail(email);
+        if (user != null) {
+            userMapper.clearRefreshTokenByUserId(user.getUserId());
+        }
+    }
+
+    /**
+     * 사용자 ID로 소셜 로그인 정보 조회 (토큰 갱신용)
+     */
+    public SocialLoginsVO findSocialLoginByUserId(Long userId) {
+        return userMapper.findSocialLoginByUserId(userId);
+    }
 
 }

--- a/src/main/java/org/bobj/user/service/UserService.java
+++ b/src/main/java/org/bobj/user/service/UserService.java
@@ -1,0 +1,143 @@
+package org.bobj.user.service;
+
+import java.util.Optional;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bobj.user.domain.SocialLoginsVO;
+import org.bobj.user.domain.UserVO;
+import org.bobj.user.dto.AdditionalInfoDTO;
+import org.bobj.user.dto.TokenDTO;
+import org.bobj.user.dto.UserResponseDTO;
+import org.bobj.user.mapper.UserMapper;
+import org.bobj.user.security.JwtTokenProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
+
+@ControllerAdvice
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserMapper userMapper;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public UserResponseDTO getUserInfo(long userId) {
+        UserVO user = userMapper.findUserById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+        return new UserResponseDTO(user);
+    }
+
+    public UserResponseDTO getUserInfoByEmail(String email) {
+        UserVO user = userMapper.findUserByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with email: " + email));
+        return new UserResponseDTO(user);
+    }
+
+    /**
+     * [로직 변경]
+     * 추가 정보와 '사전 인증 토큰'의 정보를 받아 DB에 최종 등록하고,
+     * 완전한 인증 토큰을 발급하는 메소드.
+     * @param dto 추가 정보 DTO
+     * @param preAuthClaims '사전 인증' 토큰에서 추출한 클레임 (email, nickname, provider, providerId 등)
+     * @return 최종 Access/Refresh 토큰 DTO
+     */
+    @Transactional
+    public TokenDTO registerUserAndCreateFinalToken(AdditionalInfoDTO dto, Claims preAuthClaims) {
+
+        try {
+            log.info("Pre-auth claims: {}", preAuthClaims);
+
+            log.info("최종 회원가입 및 토큰 발급 절차 시작");
+
+            // 1. 사전 인증 토큰에서 사용자 소셜 정보 추출
+//        String email = (String) preAuthClaims.get("email");
+            String email = (String) preAuthClaims.getSubject();
+            String provider = (String) preAuthClaims.get("provider");
+            String providerId = (String) preAuthClaims.get("providerId");
+
+            if (email == null || provider == null || providerId == null) {
+                throw new IllegalArgumentException("사전 인증 토큰의 정보가 올바르지 않습니다.");
+            }
+
+            // 2. DB에 이미 등록된 사용자인지 최종 확인
+            if (Optional.ofNullable(userMapper.findSocialLoginByProviderAndProviderId(provider, providerId))
+                    .orElse(Optional.empty()).isPresent()) {
+                throw new IllegalStateException("이미 등록된 소셜 계정입니다. 로그인 절차를 다시 시도해주세요.");
+            }
+
+            // 3. USERS 테이블에 사용자 저장
+            UserVO newUser = new UserVO();
+            newUser.setEmail(email);
+            newUser.setName(dto.getName());
+            newUser.setNickname(dto.getNickname()); // DTO에 닉네임 필드가 있다면 사용
+            newUser.setSsn(dto.getSsn());
+            newUser.setPhone(dto.getPhone());
+            newUser.setBankCode(dto.getBankCode());
+            newUser.setAccountNumber(dto.getAccountNumber());
+
+            userMapper.saveUser(newUser);
+            log.info("USERS 테이블에 신규 사용자 저장 완료. userId: {}", newUser.getUserId());
+
+            // 4. SOCIAL_LOGINS 테이블에 소셜 정보 저장
+            saveNewSocialLogin(newUser.getUserId(), provider, providerId, preAuthClaims);
+
+            // 5. 최종 인증 토큰 (Access/Refresh) 생성
+            String finalAccessToken = jwtTokenProvider.createAccessToken(newUser.getEmail());
+            String finalRefreshToken = jwtTokenProvider.createRefreshToken(newUser.getEmail());
+
+            // 리프레시 토큰을 DB에 저장하는 로직
+
+            log.info("최종 인증 토큰 발급 완료. email: {}", newUser.getEmail());
+            return new TokenDTO(finalAccessToken, finalRefreshToken);
+        } catch (Exception e) {
+            log.error("회원가입 및 토큰 발급 중 오류 발생", e);
+            throw e; // 필요시 커스텀 예외로 감싸도 됨
+        }
+    }
+
+//    @Transactional
+//    public TokenDTO registerUserAndCreateFinalToken(AdditionalInfoDTO dto, Claims claims) {
+//        // Claims는 Map<String, Object>를 상속해서 직접 변환 가능
+//        return registerUserAndCreateFinalToken(dto, (Map<String, Object>) claims);
+//        // 만약 형변환 문제 있으면 아래처럼 복사해서 전달 가능
+//        // return registerUserAndCreateFinalToken(dto, new HashMap<>(claims));
+//    }
+
+    private void saveNewSocialLogin(Long userId, String provider, String providerId, Map<String, Object> attributes) {
+        try {
+            String profileDataJson = objectMapper.writeValueAsString(attributes);
+            SocialLoginsVO newSocialLogin = SocialLoginsVO.builder()
+                    .userId(userId)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .profileData(profileDataJson)
+                    .build();
+            userMapper.saveSocialLogin(newSocialLogin);
+        } catch (JsonProcessingException e) {
+            log.error("소셜 프로필 JSON 변환에 실패했습니다.", e);
+            throw new RuntimeException("프로필 데이터 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+
+    public Optional<UserResponseDTO> findUserInfoByEmail(String email) {
+        return userMapper.findUserByEmail(email).map(UserResponseDTO::new);
+    }
+
+    public Optional<UserResponseDTO> findUserInfoById(Long userId) {
+        return userMapper.findUserById(userId).map(UserResponseDTO::new);
+    }
+
+
+
+}

--- a/src/main/java/org/bobj/user/util/CookieUtil.java
+++ b/src/main/java/org/bobj/user/util/CookieUtil.java
@@ -1,0 +1,54 @@
+package org.bobj.user.util;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final int ACCESS_TOKEN_MAX_AGE = 30 * 60; // 30분
+
+    /**
+     * Access Token을 HttpOnly 쿠키로 설정
+     */
+    public static void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
+        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
+        cookie.setHttpOnly(true);  // XSS 방지
+        cookie.setSecure(false);   // 개발환경에서는 false, 운영환경에서는 true
+        cookie.setPath("/");       // 모든 경로에서 접근 가능
+        cookie.setMaxAge(ACCESS_TOKEN_MAX_AGE);
+        // SameSite는 응답 헤더로 직접 설정
+        response.setHeader("Set-Cookie",
+                String.format("%s=%s; Path=/; HttpOnly; Max-Age=%d; SameSite=Strict",
+                        ACCESS_TOKEN_COOKIE_NAME, accessToken, ACCESS_TOKEN_MAX_AGE));
+    }
+
+    /**
+     * 쿠키에서 Access Token 추출
+     */
+    public static String getAccessTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access Token 쿠키 삭제 (로그아웃)
+     */
+    public static void deleteAccessTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);  // 개발환경에서는 false
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 즉시 만료
+
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.user.mapper.UserMapper">
+
+    <!-- USERS 테이블 쿼리 -->
+    <select id="findUserByEmail" resultType="org.bobj.user.domain.UserVO">
+        SELECT * FROM USERS WHERE email = #{email}
+    </select>
+
+    <select id="findUserById" resultType="org.bobj.user.domain.UserVO">
+        SELECT * FROM USERS WHERE user_id = #{userId}
+    </select>
+
+
+
+    <insert id="saveUser" useGeneratedKeys="true" keyProperty="userId">
+        <!-- 최초 가입 시에는 소셜로그인으로 받은 최소 정보만 저장 -->
+        INSERT INTO USERS (name, email, nickname, created_at, updated_at, is_admin, ssn, phone, bank_code, account_number)
+        VALUES(#{name}, #{email}, #{nickname}, NOW(), NOW(), FALSE, #{ssn}, #{phone}, #{bankCode}, #{accountNumber})
+    </insert>
+
+    <update id="updateUser" parameterType="org.bobj.user.domain.UserVO">
+        UPDATE USERS
+        SET
+            name = #{name},
+            nickname = #{nickname},
+            ssn = #{ssn},
+            phone = #{phone},
+            bank_code = #{bankCode},
+            account_number = #{accountNumber},
+            updated_at = NOW()
+        WHERE
+            user_id = #{userId}
+    </update>
+
+    <!-- SOCIAL_LOGINS 테이블 쿼리 -->
+    <select id="findSocialLoginByProviderAndProviderId" resultType="org.bobj.user.domain.SocialLoginsVO">
+        SELECT * FROM social_logins
+        WHERE provider = #{provider} AND provider_id = #{providerId}
+    </select>
+
+
+    <insert id="saveSocialLogin" parameterType="org.bobj.user.domain.SocialLoginsVO">
+        INSERT INTO social_logins (user_id, provider, provider_id, profile_data, created_at)
+        VALUES (#{userId}, #{provider}, #{providerId}, #{profileData}, NOW())
+    </insert>
+
+    <update id="updateRefreshToken" parameterType="org.bobj.user.domain.SocialLoginsVO">
+        UPDATE SOCIAL_LOGINS
+        SET refresh_token = #{refreshToken}
+        WHERE social_id = #{socialId}
+    </update>
+
+    <select id="findSocialLoginByUserId" resultType="org.bobj.user.domain.SocialLoginsVO">
+        SELECT * FROM social_logins WHERE user_id = #{userId}
+    </select>
+
+
+
+</mapper>

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -4,26 +4,25 @@
 
     <!-- USERS 테이블 쿼리 -->
     <select id="findUserByEmail" resultType="org.bobj.user.domain.UserVO">
-        SELECT * FROM USERS WHERE email = #{email}
+        SELECT * FROM users WHERE email = #{email}
     </select>
 
     <select id="findUserById" resultType="org.bobj.user.domain.UserVO">
-        SELECT * FROM USERS WHERE user_id = #{userId}
+        SELECT * FROM users WHERE user_id = #{userId}
     </select>
 
 
 
     <insert id="saveUser" useGeneratedKeys="true" keyProperty="userId">
-        <!-- 최초 가입 시에는 소셜로그인으로 받은 최소 정보만 저장 -->
-        INSERT INTO USERS (name, email, nickname, created_at, updated_at, is_admin, ssn, phone, bank_code, account_number)
-        VALUES(#{name}, #{email}, #{nickname}, NOW(), NOW(), FALSE, #{ssn}, #{phone}, #{bankCode}, #{accountNumber})
+        INSERT INTO users (name, email, nickname, ssn, phone, bank_code, account_number, is_admin, created_at, updated_at)
+        VALUES(#{name}, #{email}, #{nickname}, #{ssn}, #{phone}, #{bankCode}, #{accountNumber}, #{isAdmin}, NOW(), NOW())
     </insert>
 
+
     <update id="updateUser" parameterType="org.bobj.user.domain.UserVO">
-        UPDATE USERS
+        UPDATE users
         SET
             name = #{name},
-            nickname = #{nickname},
             ssn = #{ssn},
             phone = #{phone},
             bank_code = #{bankCode},
@@ -40,13 +39,13 @@
     </select>
 
 
-    <insert id="saveSocialLogin" parameterType="org.bobj.user.domain.SocialLoginsVO">
-        INSERT INTO social_logins (user_id, provider, provider_id, profile_data, created_at)
-        VALUES (#{userId}, #{provider}, #{providerId}, #{profileData}, NOW())
+    <insert id="saveSocialLogin" parameterType="org.bobj.user.domain.SocialLoginsVO" useGeneratedKeys="true" keyProperty="socialId">
+        INSERT INTO social_logins (user_id, provider, provider_id, refresh_token, profile_data, created_at)
+        VALUES (#{userId}, #{provider}, #{providerId}, #{refreshToken}, #{profileData}, #{createdAt})
     </insert>
 
     <update id="updateRefreshToken" parameterType="org.bobj.user.domain.SocialLoginsVO">
-        UPDATE SOCIAL_LOGINS
+        UPDATE social_logins
         SET refresh_token = #{refreshToken}
         WHERE social_id = #{socialId}
     </update>
@@ -55,6 +54,19 @@
         SELECT * FROM social_logins WHERE user_id = #{userId}
     </select>
 
+    <!-- Refresh Token으로 소셜 로그인 정보 조회 -->
+    <select id="findSocialLoginByRefreshToken" parameterType="string" resultType="org.bobj.user.domain.SocialLoginsVO">
+        SELECT social_id, user_id, provider, provider_id, profile_data, refresh_token, created_at
+        FROM social_logins
+        WHERE refresh_token = #{refreshToken}
+          AND refresh_token IS NOT NULL
+    </select>
 
+    <!-- 특정 사용자의 Refresh Token 삭제 -->
+    <update id="clearRefreshTokenByUserId" parameterType="long">
+        UPDATE social_logins
+        SET refresh_token = NULL
+        WHERE user_id = #{userId}
+    </update>
 
 </mapper>


### PR DESCRIPTION
---
name: ✨ PR 템플릿
about: 새로운 기능 구현 및 추가를 위한 PR 템플릿입니다.
---
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
JWT 기반 완전한 사용자 인증 시스템을 구현했습니다. OAuth2 카카오 로그인부터 회원가입, 토큰 관리, 권한 제어까지 전체 사용자 관리 기능을 완성했습니다.
## 🔧 작업 내용

- 구현된 API 목록
JWT 기반 인증 시스템 완전 구현

JwtTokenProvider: Access Token, Refresh Token, Pre-Auth Token 생성 및 검증
JwtAuthenticationFilter: 토큰 기반 인증 필터 및 자동 토큰 갱신
Spring Security 설정: JWT 기반 Stateless 인증 구조

- OAuth2 카카오 로그인 구현

OAuth2LoginSuccessHandler: 카카오 로그인 성공 시 Pre-Auth Token 발급
CustomOAuth2UserService: 카카오 사용자 정보 처리
OAuth2ClientConfig: 카카오 OAuth2 클라이언트 설정

- 사용자 관리 기능

회원가입 플로우: 신규 사용자 카카오 로그인 → 추가 정보 입력 → 회원가입 완료
로그인 플로우: 기존 사용자 카카오 로그인 → 즉시 토큰 발급
사용자 정보 조회: /api/users/me, /api/users/{userId}
로그아웃: 쿠키 삭제 및 Refresh Token DB에서 제거

- 토큰 관리 시스템

3단계 토큰 구조:

Pre-Auth Token (10분): 소셜 로그인 후 임시 인증
Access Token (30분): API 접근용 + 쿠키 저장
Refresh Token (7일): 자동 갱신용 + DB 저장


자동 토큰 갱신: 클라이언트 투명하게 만료된 토큰 자동 갱신
쿠키 기반 관리: HttpOnly, Secure, SameSite 보안 설정

- 권한 관리 시스템

Role 기반 권한: ADMIN/USER 역할 구분
JWT 토큰에 권한 정보 포함: role 필드로 Spring Security 표준 준수
클라이언트 권한 확인: API 응답에 isAdmin, role 정보 제공

인증 관련 API
GET /api/auth/oauth/kakao-url - 카카오 로그인 URL 제공
GET /api/auth/oauth/callback - OAuth 콜백 처리 (기존/신규 사용자 구분)
POST /api/auth/signup/complete - 신규 사용자 회원가입 완료
POST /api/auth/logout - 로그아웃 (토큰 무효화)
POST /api/auth/token/refresh - 토큰 갱신 (자동 갱신)

사용자 관리 API
GET /api/users/me - 내 정보 조회
GET /api/users/{userId} - 특정 사용자 정보 조회

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #45
Close #18 
