### PR TITLE
[CHORE] #49 Update GitHub Actions JDK version from 17 to 8 for Java 1…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '8'
 
       - name: Grant permission for gradlew
         run: chmod +x ./gradlew


### PR DESCRIPTION
---
name: 🔧 Java 8 호환을 위한 GitHub Actions 설정 수정
about: Java 버전 불일치로 인한 빌드 오류 방지 목적의 CI 설정 수정 PR입니다.
---
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

GitHub Actions에서 JDK 버전을 17로 설정하여 빌드된 WAR 파일이 Java 8 기반 Tomcat에서 실행되지 않는 문제 발생  
→ 이를 해결하기 위해 Actions의 Java 버전을 8로 변경했습니다.

## 🔧 작업 내용

- GitHub Actions `setup-java`의 `java-version`을 `17` → `8`로 수정
- 프로젝트의 `build.gradle`에서 설정한 Java 버전(`1.8`)과 일치시켜 빌드/실행 오류 방지

## ✅ 체크리스트
- [x] GitHub Actions 정상 작동 확인
- [ ] EC2 컨테이너에서 Spring WAR 정상 구동 확인
- [ ] 브라우저를 통해 8080 포트 접속 확인

## 📝 기타 참고 사항

- 이후 단계로 Nginx를 통한 프록시 연결 및 HTTPS 적용 예정

## 📎 관련 이슈
Close #49 
