### PR TITLE
[CHORE] change java version 17

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
 
       - name: Grant permission for gradlew
         run: chmod +x ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0-jdk8
+FROM tomcat:9.0-jdk17-temurin
 
 # 기존 webapps 폴더 비우기
 RUN rm -rf /usr/local/tomcat/webapps/*

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ ext {
     jacksonVersion = '2.13.5'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
main 브랜치에 대한 최신 배포 버전 설정 작업입니다.  
CI/CD 파이프라인을 Java 17 환경으로 통일하고 Docker 기반 배포가 정상적으로 동작하도록 설정을 수정했습니다.

## 🔧 작업 내용
- GitHub Actions JDK 버전 8 → 17 변경
- `build.gradle`에 `sourceCompatibility = JavaVersion.VERSION_17` 설정 추가
- Dockerfile 내 베이스 이미지 `tomcat:9.0-jdk17`으로 수정
- EC2 배포 환경과 일치하도록 빌드 및 배포 파이프라인 업데이트
- Gradle 빌드 성공 확인 및 WAR 파일 정상 배포 테스트 완료

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
- [x] EC2 배포 확인
- [x] DockerHub 이미지 푸시 확인
- [x] WAR 파일 정상 구동 확인

## 📝 기타 참고 사항

- 프로젝트 내 Java 17 설치 필요 (IntelliJ 설정 확인)

## 📎 관련 이슈
Close #54
