### PR TITLE
[FEAT] #70 Add JWT Authorize button to Swagger UI

### DIFF
--- a/src/main/java/org/bobj/config/SwaggerConfig.java
+++ b/src/main/java/org/bobj/config/SwaggerConfig.java
@@ -1,22 +1,58 @@
 package org.bobj.config;
 
+
+import java.util.Collections;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+
 
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
+            .apiInfo(new ApiInfoBuilder()
+                .title("API 문서")
+                .description("스웨거 JWT 테스트")
+                .version("1.0")
+                .build())
             .select()
-            .apis(RequestHandlerSelectors.basePackage("org.bobj")) // 여기를 컨트롤러 패키지로 설정
+            .apis(RequestHandlerSelectors.basePackage("org.bobj"))
             .paths(PathSelectors.any())
+            .build()
+            .securitySchemes(Collections.singletonList(apiKey()))
+//            .securityContexts(Collections.singletonList(securityContext()));
+            .securityContexts(Collections.emptyList()); // 🔥 아무 경로에도 인증 적용 안함
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+            .securityReferences(defaultAuth())
+            .forPaths(PathSelectors.any())
             .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope scope = new AuthorizationScope("global", "accessEverything");
+        return Collections.singletonList(new SecurityReference("JWT", new AuthorizationScope[]{scope}));
     }
 }

--- a/src/main/java/org/bobj/payment/client/PortOneClient.java
+++ b/src/main/java/org/bobj/payment/client/PortOneClient.java
@@ -1,0 +1,66 @@
+package org.bobj.payment.client;
+
+
+import java.net.http.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PortOneClient {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+
+    @Value("${portOne.api.url}")
+    private String portOneApiUrl;
+
+    @Value("${portOne.api.key}")
+    private String apiKey;
+
+    @Value("${portOne.api.secret}")
+    private String apiSecret;
+
+
+    private String getAccessToken() {
+        String url = portOneApiUrl + "/users/getToken";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        String body = String.format("{\"imp_key\":\"%s\", \"imp_secret\":\"%s\"}", apiKey, apiSecret);
+
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+        // TODO: 실제 응답 파싱해서 access_token 리턴
+        return "access_token_placeholder";
+    }
+
+    public PortOnePaymentResponse getPaymentInfo(String impUid) {
+        String accessToken = getAccessToken();
+
+        String url = portOneApiUrl + "/payments/" + impUid;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<PortOnePaymentResponse> response = restTemplate.exchange(
+            url, HttpMethod.GET, entity, PortOnePaymentResponse.class
+        );
+
+        return response.getBody();
+    }
+
+
+
+}

--- a/src/main/java/org/bobj/payment/dto/VerifyRequestDto.java
+++ b/src/main/java/org/bobj/payment/dto/VerifyRequestDto.java
@@ -1,0 +1,27 @@
+package org.bobj.payment.dto;
+
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "결제 검증 요청 DTO")
+public class VerifyRequestDto {
+
+    @ApiModelProperty(value = "포트원 imp_uid", example = "imp_123456789012", required = true)
+    private String impUid;
+
+    @ApiModelProperty(value = "결제 금액", example = "5000", required = true)
+    private BigDecimal amount;
+
+}

--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -1,26 +1,43 @@
 package org.bobj.point.controller;
 
-
-import java.math.BigDecimal;
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.common.exception.ErrorResponse;
+import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.payment.dto.VerifyRequestDto;
+import org.bobj.payment.service.PaymentService;
 import org.bobj.point.domain.PointChargeRequestVO;
 import org.bobj.point.service.PointChargeRequestService;
 import org.bobj.point.util.MerchantUidGenerator;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/point")
 @RequiredArgsConstructor
+@Log4j2
+@Api(tags = "포인트 충전 및 검증 API")
 public class PointChargeRequestController {
 
     private final PointChargeRequestService pointChargeRequestService;
+    private final PaymentService paymentService;
 
     @PostMapping("/charge")
-    public String createCharge(@RequestParam Long userId, @RequestParam BigDecimal amount){
+    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<String>> createCharge(
+        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
+        Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
         String merchantUid = MerchantUidGenerator.generate(userId);
 
         PointChargeRequestVO request = PointChargeRequestVO.builder()
@@ -31,8 +48,38 @@ public class PointChargeRequestController {
             .build();
 
         pointChargeRequestService.createChargeRequest(request);
-        return merchantUid;
+        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
     }
 
+    @PostMapping("/verify")
+    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)\n\n" +
+            "**예시:**\n" +
+            "```json\n" +
+            "{\n" +
+            "  \"status\": 400,\n" +
+            "  \"code\": \"P001\",\n" +
+            "  \"message\": \"결제 금액이 일치하지 않습니다.\",\n" +
+            "  \"path\": \"/api/point/verify\"\n" +
+            "}\n" +
+            "```",
+            response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
+        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
+        VerifyRequestDto requestDto,
+        Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
 
+        paymentService.verifyPayment(userId, requestDto);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 jdbc.driver=com.mysql.cj.jdbc.Driver
 jdbc.url=${DB_URL:jdbc:mysql://localhost:3306/hth?serverTimezone=Asia/Seoul}
 jdbc.username=${DB_USERNAME:root}
-jdbc.password=${DB_PASSWORD:0218}
+jdbc.password=${DB_PASSWORD:12345678}
 
 # JWT Configuration
 jwt.secret=${JWT_SECRET:4AXrwB26TLq1iGfOdpwf40DuAWi0faQew0goBQsQVNiWNjbOzlk3PrnzfczP/uVZpHgEPluuDZMLGkL9VLulkw==}


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Swagger UI에 JWT 인증 토큰 입력을 위한 Authorize 버튼을 추가하였습니다.

## 🔧 작업 내용
- SwaggerConfig에 ApiKey 설정 추가
- Swagger UI 상단에 Authorize 버튼 노출
- securityContext는 비워두어 실제 인증은 적용하지 않도록 설정
- 추후 Spring Security + JWT 필터 연동 시 인증 경로 적용 예정

## ✅ 체크리스트
- [x] Swagger UI에서 Authorize 버튼 확인
- [x] JWT 토큰 입력 창 정상 출력
- [x] 토큰 입력 시 헤더에 반영되는지 확인 (적용은 안 함)

## 📝 기타 참고 사항
- 현재는 인증 로직 미구현 상태로, Swagger UI 버튼만 먼저 구성하였습니다.
- 이후 Spring Security 연동 시 `securityContexts` 설정을 활성화할 예정입니다.

## 📎 관련 이슈
Close #70 
