### PR TITLE
[FEAT] #74 Add transaction to funding order creation API and Implemen…

### DIFF
--- a/src/main/java/org/bobj/funding/controller/FundingOrderController.java
+++ b/src/main/java/org/bobj/funding/controller/FundingOrderController.java
@@ -6,18 +6,16 @@ import lombok.extern.log4j.Log4j2;
 import org.bobj.common.dto.CustomSlice;
 import org.bobj.common.exception.ErrorResponse;
 import org.bobj.common.response.ApiCommonResponse;
-import org.bobj.funding.domain.FundingOrderVO;
-import org.bobj.funding.dto.FundingOrderRequestDTO;
+import org.bobj.funding.dto.FundingOrderLimitDTO;
 import org.bobj.funding.dto.FundingOrderUserResponseDTO;
 import org.bobj.funding.service.FundingOrderService;
-import org.bobj.property.dto.PropertyUserResponseDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
 
 @RestController
-@RequestMapping("/api/funding/order")
+@RequestMapping("/api/funding-order")
 @RequiredArgsConstructor
 @Log4j2
 @Api(tags="펀딩 주문 API")
@@ -26,14 +24,21 @@ public class FundingOrderController {
 
     @PostMapping
     @ApiOperation(value = "펀딩 주문 생성", notes = "펀딩 ID, 회원 ID, 구매 주식 수 정보를 통해 펀딩 주문을 생성합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "사용자 ID", required = true, dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "fundingId", value = "펀딩 ID", required = true, dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "shareCount", value = "구매 주식 수", required = true, dataType = "int", paramType = "query")
+    })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "펀딩 주문 생성 성공"),
             @ApiResponse(code = 400, message = "잘못된 요청", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
     public ResponseEntity<ApiCommonResponse<Void>> createFundingOrder(
-            @RequestBody @ApiParam(value = "펀딩 주문 요청 DTO", required = true) FundingOrderRequestDTO requestDTO) {
-        fundingOrderService.createFundingOrder(requestDTO.toVO());
+            @RequestParam Long userId,
+            @RequestParam Long fundingId,
+            @RequestParam int shareCount) {
+        fundingOrderService.createFundingOrder(userId, fundingId, shareCount);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(null));
     }
 
@@ -77,6 +82,25 @@ public class FundingOrderController {
             @RequestParam(defaultValue = "10") int size
     ){
         CustomSlice<FundingOrderUserResponseDTO> response = fundingOrderService.getFundingOrderUsers(userId, status, page, size);
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(response));
+    }
+
+    @GetMapping("/limit")
+    @ApiOperation(value = "사용자의 펀딩 주문 가능 정보 조회", notes = "주문 ID, 펀딩 ID에 따른 가능한 펀딩 주문 정보를 조회합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "사용자 ID",required = true, dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "fundingId", value = "펀딩 ID",required = true, dataType = "long", paramType = "query")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "사용자의 펀딩 주문 가능 정보 조회 성공", response = FundingOrderLimitDTO.class),
+            @ApiResponse(code = 400, message = "잘못된 요청", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<FundingOrderLimitDTO>> getFundingOrderLimit(
+            @RequestParam(defaultValue = "1") Long userId,
+            @RequestParam(defaultValue = "1") Long fundingId
+    ){
+        FundingOrderLimitDTO response = fundingOrderService.getFundingOrderLimit(userId, fundingId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(response));
     }
 }

--- a/src/main/java/org/bobj/funding/domain/FundingVO.java
+++ b/src/main/java/org/bobj/funding/domain/FundingVO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.LocalDate;
 
@@ -16,7 +17,7 @@ import java.time.LocalDate;
 public class FundingVO {
     private Long fundingId;
     private Long propertyId;
-    private Long currentAmount;
+    private BigDecimal currentAmount;
     private BigDecimal targetAmount;
     private BigDecimal currentShareAmount;
     private Integer totalShares;
@@ -24,4 +25,15 @@ public class FundingVO {
     private FundingStatus status;
     private LocalDateTime fundingStartDate;
     private LocalDateTime fundingEndDate;
+
+    // 남은 주 수 계산
+    public int getRemainingShares() {
+        BigDecimal sharePrice = BigDecimal.valueOf(5000);
+
+        int currentShares = currentAmount != null
+                ? currentAmount.divide(sharePrice, 0, RoundingMode.DOWN).intValue()
+                : 0;
+
+        return totalShares - currentShares;
+    }
 }

--- a/src/main/java/org/bobj/funding/dto/FundingOrderLimitDTO.java
+++ b/src/main/java/org/bobj/funding/dto/FundingOrderLimitDTO.java
@@ -1,0 +1,25 @@
+package org.bobj.funding.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FundingOrderLimitDTO {
+    // 주 당 가격
+    private BigDecimal ShareAmount;
+    // 남은 주 수
+    private Integer remainingShares;
+    // 남은 금액
+    private BigDecimal remainingAmount;
+    // 유저가 보유한 주 수
+    private Integer userShareCount;
+    // 현재 유저가 보유한 포인트
+    private BigDecimal userPoints;
+}

--- a/src/main/java/org/bobj/funding/mapper/FundingMapper.java
+++ b/src/main/java/org/bobj/funding/mapper/FundingMapper.java
@@ -13,8 +13,10 @@ import org.bobj.funding.dto.FundingTotalResponseDTO;
 
 @Mapper
 public interface FundingMapper {
+    // 펀딩 상세 조회
     FundingDetailResponseDTO findFundingById(@Param("fundingId") Long fundingId);
 
+    // 펀딩 모집 페이지에서 펀딩 리스트 조회
     List<FundingTotalResponseDTO> findTotal(
             @Param("category") String category,
             @Param("sort") String sort,
@@ -22,13 +24,25 @@ public interface FundingMapper {
             @Param("limit") int limit
     );
 
+    // 펀딩 성공한 펀딩 리스트 조회
     List<FundingEndedResponseDTO> findEndedFundingProperties(@Param("offset") int offset, @Param("limit") int limit);
 
+    // 펀딩 생성
     void insertFunding(@Param("propertyId") Long propertyId);
 
+    // 비관적 락을 이용한 펀딩 정보 조회
+    FundingVO findByIdWithLock(@Param("fundingId") Long fundingId);
+    // 일반 펀딩 정보 조회
+    FundingVO findById(@Param("fundingId") Long fundingId);
+    //  목표 금액 도달 시 상태 ENDED + 마감 날짜 현재로 바꾸는 처리
+    void markAsEnded(@Param("fundingId") Long fundingId);
+
+    // 펀딩 모집 금액 증가
     void increaseCurrentAmount(@Param("fundingId") Long fundingId, @Param("orderPrice") BigDecimal orderPrice);
 
+    // 펀딩 모집 금액 감소
     void decreaseCurrentAmount(@Param("fundingId") Long fundingId, @Param("orderPrice") BigDecimal orderPrice);
 
+    // 펀딩 완료 처리
     void expireFunding(@Param("fundingId") Long fundingId);
 }

--- a/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
+++ b/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
@@ -3,14 +3,19 @@ package org.bobj.funding.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.bobj.funding.domain.FundingOrderVO;
+import org.bobj.funding.dto.FundingOrderLimitDTO;
 import org.bobj.funding.dto.FundingOrderUserResponseDTO;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Mapper
 public interface FundingOrderMapper {
     // 펀딩 주문 생성
-    void insertFundingOrder(FundingOrderVO fundingOrder);
+    void insertFundingOrder(@Param("userId") Long userId,
+                            @Param("fundingId") Long fundingId,
+                            @Param("shareCount") int shareCount,
+                            @Param("orderPrice") BigDecimal orderPrice);
 
     // 주문 취소
     void refundFundingOrder(@Param("orderId") Long orderId);
@@ -21,4 +26,15 @@ public interface FundingOrderMapper {
             @Param("status") String status,
             @Param("offset") int offset,
             @Param("limit") int limit);
+
+    // 주문 가능 정보 조회
+    FundingOrderLimitDTO findFundingOrderLimit(
+            @Param("userId") Long userId,
+            @Param("fundingId") Long fundingId);
+
+    // 펀딩 ID에 해당하는 모든 주문 상태 변경
+    void markOrdersAsSuccessByFundingId(@Param("fundingId") Long fundingId);
+
+    // 펀딩 ID에 해당하는 모든 주문 조회
+    List<FundingOrderVO> findAllOrdersByFundingId(Long fundingId);
 }

--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -1,85 +1,85 @@
-package org.bobj.point.controller;
-
-import io.swagger.annotations.*;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import org.bobj.common.exception.ErrorResponse;
-import org.bobj.common.response.ApiCommonResponse;
-import org.bobj.payment.dto.VerifyRequestDto;
+//package org.bobj.point.controller;
+//
+//import io.swagger.annotations.*;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.log4j.Log4j2;
+//import org.bobj.common.exception.ErrorResponse;
+//import org.bobj.common.response.ApiCommonResponse;
+//import org.bobj.payment.dto.VerifyRequestDto;
 //import org.bobj.payment.service.PaymentService;
-import org.bobj.point.domain.PointChargeRequestVO;
-import org.bobj.point.service.PointChargeRequestService;
-import org.bobj.point.util.MerchantUidGenerator;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.math.BigDecimal;
-import java.security.Principal;
-
-@RestController
-@RequestMapping("/api/point")
-@RequiredArgsConstructor
-@Log4j2
-@Api(tags = "포인트 충전 및 검증 API")
-public class PointChargeRequestController {
-
-    private final PointChargeRequestService pointChargeRequestService;
+//import org.bobj.point.domain.PointChargeRequestVO;
+//import org.bobj.point.service.PointChargeRequestService;
+//import org.bobj.point.util.MerchantUidGenerator;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.math.BigDecimal;
+//import java.security.Principal;
+//
+//@RestController
+//@RequestMapping("/api/point")
+//@RequiredArgsConstructor
+//@Log4j2
+//@Api(tags = "포인트 충전 및 검증 API")
+//public class PointChargeRequestController {
+//
+//    private final PointChargeRequestService pointChargeRequestService;
 //    private final PaymentService paymentService;
-
-    @PostMapping("/charge")
-    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
-        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
-        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-    })
-    public ResponseEntity<ApiCommonResponse<String>> createCharge(
-        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
-        Principal principal
-    ) {
-        Long userId = Long.parseLong(principal.getName());
-        String merchantUid = MerchantUidGenerator.generate(userId);
-
-        PointChargeRequestVO request = PointChargeRequestVO.builder()
-            .userId(userId)
-            .amount(amount)
-            .merchantUid(merchantUid)
-            .status("PENDING")
-            .build();
-
-        pointChargeRequestService.createChargeRequest(request);
-        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
-
-        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
-    }
-
-    @PostMapping("/verify")
-    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
-        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)\n\n" +
-            "**예시:**\n" +
-            "```json\n" +
-            "{\n" +
-            "  \"status\": 400,\n" +
-            "  \"code\": \"P001\",\n" +
-            "  \"message\": \"결제 금액이 일치하지 않습니다.\",\n" +
-            "  \"path\": \"/api/point/verify\"\n" +
-            "}\n" +
-            "```",
-            response = ErrorResponse.class),
-        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-    })
-    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
-        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
-        VerifyRequestDto requestDto,
-        Principal principal
-    ) {
-        Long userId = Long.parseLong(principal.getName());
-        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
-
+//
+//    @PostMapping("/charge")
+//    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
+//    @ApiResponses(value = {
+//        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
+//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
+//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+//    })
+//    public ResponseEntity<ApiCommonResponse<String>> createCharge(
+//        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
+//        Principal principal
+//    ) {
+//        Long userId = Long.parseLong(principal.getName());
+//        String merchantUid = MerchantUidGenerator.generate(userId);
+//
+//        PointChargeRequestVO request = PointChargeRequestVO.builder()
+//            .userId(userId)
+//            .amount(amount)
+//            .merchantUid(merchantUid)
+//            .status("PENDING")
+//            .build();
+//
+//        pointChargeRequestService.createChargeRequest(request);
+//        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
+//
+//        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
+//    }
+//
+//    @PostMapping("/verify")
+//    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
+//    @ApiResponses(value = {
+//        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
+//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)\n\n" +
+//            "**예시:**\n" +
+//            "```json\n" +
+//            "{\n" +
+//            "  \"status\": 400,\n" +
+//            "  \"code\": \"P001\",\n" +
+//            "  \"message\": \"결제 금액이 일치하지 않습니다.\",\n" +
+//            "  \"path\": \"/api/point/verify\"\n" +
+//            "}\n" +
+//            "```",
+//            response = ErrorResponse.class),
+//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+//    })
+//    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
+//        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
+//        VerifyRequestDto requestDto,
+//        Principal principal
+//    ) {
+//        Long userId = Long.parseLong(principal.getName());
+//        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
+//
 //        paymentService.verifyPayment(userId, requestDto);
-
-        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
-    }
-}
+//
+//        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
+//    }
+//}

--- a/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
@@ -92,21 +92,14 @@
     WHERE p.property_id = #{propertyId}
   </insert>
 
-  <!-- 펀딩 주문 후 모집 금액 수정 -->
-  <update id="increaseCurrentAmount">
-    UPDATE fundings
-        SET current_amount = current_amount + #{orderPrice}
-    WHERE funding_id = #{fundingId};
-  </update>
-
-  <!-- 펀딩 취소 후 모집 금액 수정 -->
+  <!-- 펀딩 모집 금액 감소 -->
   <update id="decreaseCurrentAmount">
     UPDATE fundings
         SET current_amount = current_amount - #{orderPrice}
     WHERE funding_id = #{fundingId};
   </update>
 
-  <!-- 펀딩 만료 후 일괄 환불 -->
+  <!-- 펀딩 완료 처리 -->
   <update id="expireFunding">
     UPDATE fundings f
         JOIN funding_order o ON f.funding_id = o.funding_id
@@ -172,6 +165,8 @@
     </choose>
     LIMIT #{limit} OFFSET #{offset}
   </select>
+
+  <!-- 펀딩 성공한 펀딩 리스트 조회 -->
   <select id="findEndedFundingProperties" resultType="org.bobj.funding.dto.FundingEndedResponseDTO">
     SELECT f.funding_id, p.title
     FROM fundings f
@@ -180,4 +175,34 @@
     ORDER BY f.funding_end_date DESC
     LIMIT #{limit} OFFSET #{offset}
   </select>
+
+  <!-- 비관적 락을 이용한 펀딩 정보 조회 -->
+  <select id="findByIdWithLock" resultType="org.bobj.funding.domain.FundingVO">
+    SELECT funding_id, property_id, target_amount, current_amount, total_shares, status
+    FROM fundings
+    WHERE funding_id = #{fundingId}
+      FOR UPDATE
+  </select>
+
+  <!-- 일반 펀딩 정보 조회 -->
+  <select id="findById" resultType="org.bobj.funding.domain.FundingVO">
+    SELECT funding_id, property_id, target_amount, current_amount, total_shares, status
+    FROM fundings
+    WHERE funding_id = #{fundingId}
+  </select>
+
+  <!-- 펀딩 주문 후 모집 금액 증가 -->
+  <update id="increaseCurrentAmount">
+    UPDATE fundings
+    SET current_amount = current_amount + #{orderPrice}
+    WHERE funding_id = #{fundingId};
+  </update>
+
+  <!-- 목표 금액 도달 시 상태 ENDED + 마감 날짜 현재로 바꾸는 처리 -->
+  <update id="markAsEnded">
+    UPDATE fundings
+    SET status = 'ENDED',
+        funding_end_date = NOW()
+    WHERE funding_id = #{fundingId}
+  </update>
 </mapper>

--- a/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
@@ -3,6 +3,7 @@
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.funding.mapper.FundingOrderMapper">
+
   <!-- 내가 투자한 주문 리스트 -->
   <select id="findFundingOrdersByUserId" resultType="org.bobj.funding.dto.FundingOrderUserResponseDTO">
     SELECT
@@ -51,13 +52,11 @@
     </association>
   </resultMap>
 
-  <!-- 주문 삽입 -->
-  <insert id="insertFundingOrder" parameterType="FundingOrderVO">
+  <!-- 펀딩 주문 생성 -->
+  <insert id="insertFundingOrder">
     INSERT INTO funding_order (
       user_id, funding_id, share_count, order_price
-    ) VALUES (
-               #{userId}, #{fundingId}, #{shareCount}, #{shareCount} * 5000
-             )
+    ) VALUES (#{userId}, #{fundingId}, #{shareCount}, #{shareCount} * 5000)
   </insert>
 
   <!-- 주문 취소 -->
@@ -66,4 +65,52 @@
     SET status = 'REFUNDED'
     WHERE order_id = #{orderId}
   </update>
+
+    <!-- 주문 가능 정보 조회 -->
+    <select id="findFundingOrderLimit" resultType="org.bobj.funding.dto.FundingOrderLimitDTO">
+        SELECT
+            5000 AS share_price,
+
+            -- 펀딩 관련
+            f.target_amount - f.current_amount AS remaining_amount,
+            (f.target_amount - f.current_amount) / 5000 AS remaining_shares,
+
+            -- 유저 보유 주 수
+            IFNULL((
+                       SELECT SUM(fo.share_count)
+                       FROM funding_order fo
+                       WHERE fo.funding_id = f.funding_id
+                         AND fo.user_id = #{userId}
+                         AND fo.status = 'PENDING'
+                   ), 0) AS user_share_count,
+
+            -- 유저 포인트
+            u.amount AS user_points
+
+        FROM fundings f
+                 JOIN point u ON u.user_id = #{userId}
+        WHERE f.funding_id = #{fundingId}
+    </select>
+
+    <!-- 펀딩 ID에 해당하는 모든 주문 조회 -->
+    <select id="findAllOrdersByFundingId" resultType="org.bobj.funding.domain.FundingOrderVO">
+        SELECT order_id,
+               user_id,
+               funding_id,
+               share_count,
+               order_price,
+               status,
+               created_at
+        FROM funding_order
+        WHERE funding_id = #{fundingId}
+          AND status = 'PENDING'
+    </select>
+
+    <!-- 펀딩 ID에 해당하는 모든 주문 상태 변경 -->
+    <update id="markOrdersAsSuccessByFundingId">
+        UPDATE funding_order
+        SET status = 'SUCCESS'
+        WHERE funding_id = #{fundingId}
+          AND status = 'PENDING'
+    </update>
 </mapper>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
펀딩 성공 로직 완성
펀딩 주문 생성 시 트랜젝션으로 동시성 제어

## 🔧 작업 내용

## ✅ 체크리스트
- [ ] 동시성 제어에 필요한 기능들 구현
- [ ] 펀딩 주문 생성 API 수정 완료
- [ ] 펀딩 성공 판단 로직 + update문 작성 완료

## 📝 기타 참고 사항
Shares 테이블 / Point 테이블 담당자들이 추후 기능 추가 예정


## 📎 관련 이슈
Close #74
