### PR TITLE
[CHORE] Inject application.properties via GitHub Actions secret for C…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,16 +10,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Grant permission for gradlew
         run: chmod +x ./gradlew
+
+      - name: Inject application.properties
+        run: |
+          mkdir -p src/main/resources
+          cat <<EOF > src/main/resources/application.properties
+          ${{ secrets.APP_PROPERTIES }}
+          EOF
 
       - name: Build WAR file (Skip tests)
         run: ./gradlew build -x test
@@ -51,24 +58,13 @@ jobs:
         run: |
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Deploy Docker container to EC2
+      - name: Deploy with docker-compose (from /home/ubuntu/app)
         run: |
-          ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} << 'EOF'
-          docker pull yyssjjj/bobj:latest
-          docker stop bobj || true
-          docker rm bobj || true
-          docker run -d \
-            --name bobj \
-            -p 8080:8080 \
-            -e DB_URL="${{ secrets.DB_URL }}" \
-            -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
-            -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
-            -e JWT_SECRET="${{ secrets.JWT_SECRET }}" \
-            -e CRYPTO_MASTER_KEY="${{ secrets.CRYPTO_MASTER_KEY }}\" \
-            -e KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
-            -e KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
-            -e OAUTH_REDIRECT_URI="${{ secrets.OAUTH_REDIRECT_URI }}" \
-            -e FRONTEND_REDIRECT_URI="${{ secrets.FRONTEND_REDIRECT_URI }}" \
-            -e SERVER_DOMAIN="${{ secrets.SERVER_DOMAIN }}" \
-            yyssjjj/bobj:latest
+          ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} <<EOF
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          cd /home/ubuntu/app
+          docker compose down || true
+          docker compose pull
+          docker compose up -d
+          docker compose ps
           EOF


### PR DESCRIPTION
---
name: ⚙️ CI/CD 개선
about: GitHub Actions 배포 환경 설정 변경을 위한 PR입니다.
---

## 🔖 PR 유형
- [x] ⚙️ CI/CD 설정
- [ ] 🐛 버그 수정
- [ ] ✨ 기능 추가
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

GitHub Actions에서 `application.properties`를 Git에 올리지 않고도 시크릿으로 주입하여 빌드에 사용할 수 있도록 워크플로우 수정

## 🛠️ 작업 내용

- `${{ secrets.APP_PROPERTIES }}`를 `application.properties`로 생성하는 Step 추가
- 기존 Git 추적에서 제외된 설정 파일을 안전하게 주입하여 보안 및 유지보수 개선
- CI 빌드 중 정상적으로 WAR 파일 생성되도록 보장

## ✅ 체크리스트

- [x] GitHub Secrets에 `APP_PROPERTIES` 등록됨
- [x] main 브랜치에서 정상적으로 워크플로우 작동함
- [x] EC2 서버에서 `application.properties` 파일 주입 후 실행됨

## 📝 기타 참고 사항

- 팀원들은 로컬 `.gitignore` 유지하고, EC2 배포 환경에서는 자동으로 주입되는 방식 유지

## 📎 관련 이슈
Close #81 
