### PR TITLE
[FEAT] Implement API to retrieve trade history

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,10 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
-
+    //Stomp
+    implementation "org.springframework:spring-websocket:${springVersion}"
+    implementation "org.springframework:spring-messaging:${springVersion}"
+    implementation "org.springframework.integration:spring-integration-stomp:5.5.20"
 
 
 // xml내 한글 처리
@@ -112,8 +115,6 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
     testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
-
-
 
 
 }

--- a/src/main/java/org/bobj/common/ActiveSubscriptionsChecker.java
+++ b/src/main/java/org/bobj/common/ActiveSubscriptionsChecker.java
@@ -1,0 +1,40 @@
+package org.bobj.common;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class ActiveSubscriptionsChecker {
+
+    private final SimpUserRegistry simpUserRegistry;
+
+    public int getSubscriberCountForTopic(String destination) {
+        int count = 0;
+
+        // 연결된 사용자(세션)들을 순회
+        for (var user : simpUserRegistry.getUsers()) {
+            // 각 사용자의 세션들 순회
+            for (var session : user.getSessions()) {
+                // 각 세션의 구독 정보 순회
+                boolean subscribed = session.getSubscriptions().stream()
+                        .anyMatch(subscription -> destination.equals(subscription.getDestination()));
+
+                if (subscribed) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+}

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -20,14 +20,15 @@ import org.springframework.web.servlet.view.JstlView;
         "org.bobj.share.controller",
         "org.bobj.funding.controller",
         "org.bobj.user.controller",
-        "org.bobj.orderbook.controller"})
+        "org.bobj.orderbook.controller",
+        "org.bobj.funding.controller",})
 public class ServletConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
-            .addResourceHandler("/resources/**") // url이 /resources/로 시작하는 모든 경로
-            .addResourceLocations("/resources/"); // webapp/resources/경로로 매핑
+                .addResourceHandler("/resources/**") // url이 /resources/로 시작하는 모든 경로
+                .addResourceLocations("/resources/"); // webapp/resources/경로로 매핑
     }
 
     // jsp view resolver 설정

--- a/src/main/java/org/bobj/config/WebConfig.java
+++ b/src/main/java/org/bobj/config/WebConfig.java
@@ -1,17 +1,17 @@
 package org.bobj.config;
 
 import javax.servlet.Filter;
+
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
 public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitializer {
 
 
-
     // 루트 설정 클래스 (DB, 보안 등 전역 설정)
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[] { RootConfig.class };
+        return new Class[]{RootConfig.class};
     }
 
 
@@ -19,15 +19,17 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     @Override
     protected Class<?>[] getServletConfigClasses() {
         return new Class[]{
-            SwaggerConfig.class,
-            ServletConfig.class,
+                SwaggerConfig.class,
+                ServletConfig.class,
                 SecurityConfig.class,
+                WebSocketConfig.class
         };
     }
+
     // 스프링의 FrontController인 DispatcherServlet이 담당할 Url 매핑 패턴, / : 모든 요청에 대해 매핑
     @Override
     protected String[] getServletMappings() {
-        return new String[] { "/" };
+        return new String[]{"/"};
     }
 
     // POST body 문자 인코딩 필터 설정 - UTF-8 설정
@@ -35,9 +37,8 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
         CharacterEncodingFilter characterEncodingFilter = new CharacterEncodingFilter();
         characterEncodingFilter.setEncoding("UTF-8");
         characterEncodingFilter.setForceEncoding(true);
-        return new Filter[] {characterEncodingFilter};
+        return new Filter[]{characterEncodingFilter};
     }
-
 
 
 }

--- a/src/main/java/org/bobj/config/WebSocketConfig.java
+++ b/src/main/java/org/bobj/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package org.bobj.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); //메세지 수신 /topic/토픽번호
+
+        registry.setApplicationDestinationPrefixes("/app");  //메세지 발행  /app로 시작하는 url패턴으로 메시지가 발행되면
+        //@Controller객체의 @MessageMapping메서드로 메세지가 라우팅된다.
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/order-book") // 접속 엔드포인트, ws://localhost:8080/order-book
+                .setAllowedOriginPatterns("*")
+//                .setAllowedOrigins("*") // CORS 허용 - 프론트엔드 도메인 주소로 나중에 변경 필요
+                .withSockJS(); //ws://가 아닌 http:// 엔드포인트를 사용할 수 있도록 해줌
+    }
+
+}

--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -5,6 +5,8 @@ import lombok.extern.log4j.Log4j2;
 import org.bobj.order.domain.OrderVO;
 import org.bobj.order.domain.OrderType;
 import org.bobj.order.mapper.OrderMapper;
+import org.bobj.orderbook.service.OrderBookService;
+import org.bobj.orderbook.service.OrderBookWebSocketService;
 import org.bobj.point.domain.PointVO;
 import org.bobj.point.service.PointService;
 import org.bobj.share.domain.ShareVO;
@@ -26,6 +28,9 @@ public class OrderMatchingService {
     private final TradeMapper tradeMapper;
     private final ShareMapper shareMapper;
     private final PointService pointService;
+
+    private final OrderBookService orderBookService;
+    private final OrderBookWebSocketService orderBookWebSocketService;
 
     @Transactional
     public void processOrderMatching(OrderVO newOrder) {
@@ -116,6 +121,9 @@ public class OrderMatchingService {
             // 매도자 포인트 업데이트
             processSellTradeAssets(sellerUserId, newOrder.getFundingId(), tradeCount, actualTradePrice);
         }
+
+        // 모든 체결 처리 후 최종 호가창 업데이트를 웹소켓으로 푸시
+        orderBookWebSocketService.publishOrderBookUpdate(newOrder.getFundingId());
     }
 
     // 매수자 포인트 업데이트

--- a/src/main/java/org/bobj/order/service/OrderServiceImpl.java
+++ b/src/main/java/org/bobj/order/service/OrderServiceImpl.java
@@ -8,6 +8,8 @@ import org.bobj.order.domain.OrderType;
 import org.bobj.order.dto.request.OrderRequestDTO;
 import org.bobj.order.dto.response.OrderResponseDTO;
 import org.bobj.order.mapper.OrderMapper;
+import org.bobj.orderbook.service.OrderBookService;
+import org.bobj.orderbook.service.OrderBookWebSocketService;
 import org.bobj.share.mapper.ShareMapper;
 import org.bobj.share.service.ShareService;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ public class OrderServiceImpl implements OrderService {
 
     //주문 체결 서비스
     private final OrderMatchingService orderMatchingService;
+    private final OrderBookWebSocketService orderBookWebSocketService;
 
     @Override
     public OrderResponseDTO getOrderById(Long orderId) {
@@ -121,6 +124,8 @@ public class OrderServiceImpl implements OrderService {
         }
 
         orderMapper.cancelOrder(orderId);
-    }
 
+        // 주문 취소 후 호가창 업데이트를 웹소켓으로 푸시
+        orderBookWebSocketService.publishOrderBookUpdate(orderBook.getFundingId());
+    }
 }

--- a/src/main/java/org/bobj/orderbook/controller/OrderBookWebSocketController.java
+++ b/src/main/java/org/bobj/orderbook/controller/OrderBookWebSocketController.java
@@ -1,0 +1,37 @@
+package org.bobj.orderbook.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.orderbook.dto.response.OrderBookResponseDTO;
+import org.bobj.orderbook.service.OrderBookService;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
+import org.springframework.stereotype.Controller;
+
+@Log4j2
+@Controller
+@RequiredArgsConstructor
+@Api(tags = "호가창 실시간 WebSocket API")
+public class OrderBookWebSocketController {
+
+    private final OrderBookService orderBookService;
+
+    @MessageMapping("/order-book/{fundingId}")
+    @SendTo("/topic/order-book/{fundingId}")
+    @ApiOperation(value = "호가창 실시간 구독", notes = "STOMP 메시지를 통해 해당 펀딩의 호가창을 실시간으로 받아옵니다.")
+    public OrderBookResponseDTO sendMessage(@DestinationVariable Long fundingId){
+
+
+        OrderBookResponseDTO orderBook = orderBookService.getOrderBookByFundingId(fundingId);
+        log.info("OrderBookWebSocketController - sendMessage 호출됨!");
+        log.info("수신된 fundingId: {}", fundingId);
+        log.info("수신된 메시지: {}", orderBook);
+
+        return orderBook;
+    }
+}

--- a/src/main/java/org/bobj/orderbook/service/OrderBookServiceImpl.java
+++ b/src/main/java/org/bobj/orderbook/service/OrderBookServiceImpl.java
@@ -2,6 +2,7 @@ package org.bobj.orderbook.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.bobj.common.ActiveSubscriptionsChecker;
 import org.bobj.funding.domain.FundingVO;
 import org.bobj.funding.dto.FundingDetailResponseDTO;
 import org.bobj.funding.mapper.FundingMapper;
@@ -14,6 +15,7 @@ import org.bobj.property.domain.PropertyVO;
 import org.bobj.property.mapper.PropertyMapper;
 import org.bobj.trade.domain.TradeVO;
 import org.bobj.trade.mapper.TradeMapper;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +40,7 @@ public class OrderBookServiceImpl implements OrderBookService{
 
     // 상한가/하한가 계산을 위한 비율
     private static final BigDecimal LIMIT_PERCENTAGE = new BigDecimal("0.30"); // 30%
+    private final ActiveSubscriptionsChecker subscriptionsChecker;
 
     @Transactional(readOnly = true)
     @Override
@@ -102,4 +105,5 @@ public class OrderBookServiceImpl implements OrderBookService{
                 .sorted(Comparator.comparing(OrderBookEntryDTO::getPrice, sortOrder))
                 .collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/org/bobj/orderbook/service/OrderBookWebSocketService.java
+++ b/src/main/java/org/bobj/orderbook/service/OrderBookWebSocketService.java
@@ -1,0 +1,31 @@
+package org.bobj.orderbook.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.order.mapper.OrderMapper;
+import org.bobj.orderbook.dto.response.OrderBookResponseDTO;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class OrderBookWebSocketService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final OrderBookService orderBookService;
+
+    // 호가창 업데이트를 웹소켓으로 발행
+    public void publishOrderBookUpdate(Long fundingId) {
+        try {
+            OrderBookResponseDTO orderBook = orderBookService.getOrderBookByFundingId(fundingId);
+            String destination = "/topic/order-book/" + fundingId;
+
+            messagingTemplate.convertAndSend(destination, orderBook);
+            log.info("Order book update published to topic {}: {}", destination, orderBook);
+        } catch (Exception e) {
+            log.error("Failed to publish order book update for fundingId {}: {}", fundingId, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/org/bobj/socket/WebSocketEventListener.java
+++ b/src/main/java/org/bobj/socket/WebSocketEventListener.java
@@ -1,0 +1,99 @@
+//package org.bobj.socket;
+//
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.bobj.common.ActiveSubscriptionsChecker;
+//import org.springframework.context.event.EventListener;
+//import org.springframework.messaging.simp.user.SimpUserRegistry;
+//import org.springframework.stereotype.Component;
+//import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+//import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+//import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+//
+//import java.util.Set;
+//import java.util.concurrent.ConcurrentHashMap;
+//
+//@Component
+//@Slf4j
+//@RequiredArgsConstructor
+//public class WebSocketEventListener {
+//
+//    private final ConcurrentHashMap<String, Set<String>> sessionSubscriptions = new ConcurrentHashMap<>();
+//    private final SimpUserRegistry simpUserRegistry;
+//
+//    @EventListener
+//    public void handleSubscribeEvent(SessionSubscribeEvent event) {
+//
+//        log.info("WebSocketEventListener 주입된 SimpUserRegistry 해시코드: {}", System.identityHashCode(simpUserRegistry)); // <-- 추가
+//
+//
+//        String sessionId = (String) event.getMessage().getHeaders().get("simpSessionId");
+//        String destination = (String) event.getMessage().getHeaders().get("simpDestination");
+//        log.info("✅ 세션 {} 이 {} 토픽을 구독했습니다.", sessionId, destination);
+//
+//        // 해당 세션의 구독 목록에 현재 토픽 추가
+//        sessionSubscriptions.computeIfAbsent(sessionId, k -> ConcurrentHashMap.newKeySet()).add(destination);
+//
+//        // --- 여기에서 호출 ---
+//        logCurrentSubscribers(destination);
+//    }
+//
+//    @EventListener
+//    public void handleUnsubscribeEvent(SessionUnsubscribeEvent event) {
+//        String sessionId = (String) event.getMessage().getHeaders().get("simpSessionId");
+//        String destination = (String) event.getMessage().getHeaders().get("simpDestination");
+//        log.info("❌ 세션 {} 이 {} 토픽 구독을 해제했습니다.", sessionId, destination);
+//
+//        // 해당 세션의 구독 목록에서 현재 토픽 제거
+//        if (sessionSubscriptions.containsKey(sessionId)) {
+//            sessionSubscriptions.get(sessionId).remove(destination);
+//            // 만약 해당 세션이 더 이상 어떤 토픽도 구독하고 있지 않다면 맵에서 제거
+//            if (sessionSubscriptions.get(sessionId).isEmpty()) {
+//                sessionSubscriptions.remove(sessionId);
+//            }
+//        }
+//
+//        // --- 여기에서 호출 ---
+//        logCurrentSubscribers(destination);
+//    }
+//
+//    @EventListener
+//    public void handleDisconnectEvent(SessionDisconnectEvent event) {
+//        String sessionId = (String) event.getMessage().getHeaders().get("simpSessionId");
+//        log.info("🔴 세션 {} 연결이 끊어졌습니다.", sessionId);
+//
+//        // 연결이 끊어진 세션이 구독했던 모든 토픽에 대해 구독자 수 업데이트 로깅을 하려면
+//        // 해당 세션이 구독했던 토픽 목록을 가져와서 각각 logCurrentSubscribers를 호출해야 합니다.
+//        // 예를 들어:
+//        Set<String> subscribedTopics = sessionSubscriptions.remove(sessionId);
+//        if (subscribedTopics != null) {
+//            for (String topic : subscribedTopics) {
+//                logCurrentSubscribers(topic); // 연결 해제로 인해 구독자 수가 줄어든 토픽에 대해 로깅
+//            }
+//        }
+//        // 이 부분은 연결 끊김 시점에 어떤 토픽에서 구독 해제되는지 정확히 파악하여 로그를 남기는 로직입니다.
+//        // 단, 세션이 끊어질 때 모든 구독이 자동으로 해지되므로, 명시적인 UNSUBSCRIBE 이벤트가 발생하지 않을 수 있어
+//        // DISCONNECT 이벤트에서 처리하는 것이 중요합니다.
+//    }
+//
+//    // 특정 토픽의 현재 구독자 수를 로깅하는 헬퍼 메서드
+//    private void logCurrentSubscribers(String destination) {
+//        long count = sessionSubscriptions.entrySet().stream()
+//                .filter(entry -> entry.getValue().contains(destination))
+//                .count();
+//        log.info("📊 토픽 {} 에 {} 개의 클라이언트가 구독 중입니다. (EventListener 내부 집계)", destination, count);
+//    }
+//
+//    // 외부에서 특정 세션이 구독 중인지 확인하는 메서드 (필요시)
+//    public boolean isSessionSubscribedToTopic(String sessionId, String topic) {
+//        return sessionSubscriptions.containsKey(sessionId) && sessionSubscriptions.get(sessionId).contains(topic);
+//    }
+//
+//    // 특정 토픽의 현재 구독자 수를 반환하는 메서드 (외부에서 호출할 경우)
+//    public int getSubscriberCountForTopic(String destination) {
+//        return (int) sessionSubscriptions.entrySet().stream()
+//                .filter(entry -> entry.getValue().contains(destination))
+//                .count();
+//    }
+//
+//}

--- a/src/main/java/org/bobj/trade/dto/DailyTradeHistoryDTO.java
+++ b/src/main/java/org/bobj/trade/dto/DailyTradeHistoryDTO.java
@@ -1,5 +1,6 @@
 package org.bobj.trade.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 public class DailyTradeHistoryDTO {
 
     @ApiModelProperty(value = "날짜 (YYYY-MM-DD)", example = "2025-07-24", required = true)
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
     @ApiModelProperty(value = "해당 날짜의 종가", example = "5090.0", required = true)

--- a/src/main/java/org/bobj/trade/mapper/TradeMapper.java
+++ b/src/main/java/org/bobj/trade/mapper/TradeMapper.java
@@ -2,6 +2,7 @@ package org.bobj.trade.mapper;
 
 import org.apache.ibatis.annotations.Param;
 import org.bobj.trade.domain.TradeVO;
+import org.bobj.trade.dto.DailyTradeHistoryDTO;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -22,4 +23,15 @@ public interface TradeMapper {
 
     //가장 최근 체결 가격 조회
     BigDecimal findLatestTradePriceByFundingId(@Param("fundingId") Long fundingId);
+
+    /**
+     * 특정 펀딩에 대한 일별 체결 내역을 조회합니다.
+     * 각 날짜의 종가(마지막 거래 가격)와 총 거래량을 집계
+     */
+    List<DailyTradeHistoryDTO> findDailyTradeSummary(
+            @Param("fundingId") Long fundingId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }
+

--- a/src/main/java/org/bobj/trade/service/TradeHistoryServiceImpl.java
+++ b/src/main/java/org/bobj/trade/service/TradeHistoryServiceImpl.java
@@ -3,6 +3,7 @@ package org.bobj.trade.service;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.trade.domain.TradeVO;
 import org.bobj.trade.dto.DailyTradeHistoryDTO;
 import org.bobj.trade.dto.request.TradeHistoryRequestDTO;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
@@ -27,15 +29,70 @@ import java.util.stream.Stream;
 public class TradeHistoryServiceImpl implements TradeHistoryService{
 
     private final TradeMapper tradeMapper;
-
-    // 기본 조회 개수 (60개)
-    private static final int DEFAULT_HISTORY_COUNT = 60;
-    // 기본 조회 기간을 계산할 때 사용될 최소 백업 기간 (예: 6개월)
-    // 60개의 거래일 데이터를 확보하기 위해 충분히 넓은 기간을 설정합니다.
-    private static final long DEFAULT_LOOKBACK_MONTHS = 6;
+    private final FundingMapper fundingMapper;
 
     @Transactional(readOnly = true)
+    @Override
     public FundingTradeHistoryResponseDTO getDailyTradeHistory(Long fundingId, TradeHistoryRequestDTO requestDTO) {
-        return null;
+        // 펀딩 존재 여부 확인 (필수)
+        if (fundingMapper.findFundingById(fundingId) == null) {
+
+            throw new IllegalArgumentException("funding id에 대한 펀딩이 존재하지 않습니다.");
+        }
+
+        // 일별 체결 요약 데이터 조회
+        List<DailyTradeHistoryDTO> dailySummaries = tradeMapper.findDailyTradeSummary(fundingId, requestDTO.getStartDate(), requestDTO.getEndDate());
+
+        // 변화율 계산
+        List<DailyTradeHistoryDTO> historyWithChangeRate = calculateChangeRates(dailySummaries);
+
+        return FundingTradeHistoryResponseDTO.builder()
+                .fundingId(fundingId)
+                .history(historyWithChangeRate)
+                .build();
     }
+
+    //일별 체결 내역 리스트에 전일 대비 변화율을 계산
+    private List<DailyTradeHistoryDTO> calculateChangeRates(List<DailyTradeHistoryDTO> dailySummaries) {
+        if (dailySummaries == null || dailySummaries.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<DailyTradeHistoryDTO> result = new ArrayList<>();
+        BigDecimal previousPrice = null;
+
+
+        for (DailyTradeHistoryDTO current : dailySummaries) {
+            BigDecimal currentPrice = current.getClosingPrice(); // 현재 날짜의 종가
+
+            // 1. 단일 변화율 계산
+            BigDecimal changeRate = calculateSingleChangeRate(currentPrice, previousPrice);
+
+            result.add(DailyTradeHistoryDTO.builder()
+                    .date(current.getDate())
+                    .closingPrice(current.getClosingPrice())
+                    .volume(current.getVolume())
+                    .priceChangeRate(changeRate)
+                    .build());
+
+            previousPrice = currentPrice; // 현재 가격을 다음 반복을 위한 이전 가격으로 설정
+
+        }
+        return result;
+    }
+
+    private BigDecimal calculateSingleChangeRate(BigDecimal currentPrice, BigDecimal previousPrice) {
+        // 이전 가격이 없거나 0일 경우, 변화율은 0으로 간주
+        if (previousPrice == null || previousPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        // (현재가 - 전일가) / 전일가 * 100
+        return currentPrice.subtract(previousPrice)
+                .divide(previousPrice, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"))
+                .setScale(2, RoundingMode.HALF_UP); // 최종 변화율 소수점 2자리까지
+    }
+
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,40 @@
+# Database Configuration
+jdbc.driver=com.mysql.cj.jdbc.Driver
+jdbc.url=${DB_URL:jdbc:mysql://localhost:3306/hth?serverTimezone=UTC}
+jdbc.username=${DB_USERNAME:root}
+jdbc.password=${DB_PASSWORD:0218}
+
+# JWT Configuration
+jwt.secret=${JWT_SECRET:4AXrwB26TLq1iGfOdpwf40DuAWi0faQew0goBQsQVNiWNjbOzlk3PrnzfczP/uVZpHgEPluuDZMLGkL9VLulkw==}
+
+# JWT Token Expiration Settings (minutes)
+jwt.access-token-expire-minutes=${JWT_ACCESS_TOKEN_EXPIRE:30}
+jwt.refresh-token-expire-days=${JWT_REFRESH_TOKEN_EXPIRE:7}
+jwt.pre-auth-token-expire-minutes=${JWT_PRE_AUTH_TOKEN_EXPIRE:10}
+
+jwt.preemptive-refresh-minutes=${JWT_PREEMPTIVE_REFRESH_MINUTES:5}
+jwt.preemptive-refresh-enabled=${JWT_PREEMPTIVE_REFRESH_ENABLED:true}
+
+# Kakao OAuth2 Client Registration
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:d6f410db14e162483d6845398daf3718}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET:37dIrL5vdJT4uE4PrAjr7HrNc2LqKTgm}
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,account_email
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri=${OAUTH_REDIRECT_URI:http://localhost:8080/login/oauth2/code/kakao}
+
+# Custom OAuth2 Configuration
+custom.oauth2.redirect-uri=${FRONTEND_REDIRECT_URI:http://localhost:5173/auth/callback}
+
+# Kakao OAuth2 Provider Configuration
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# Personal Data Encryption Configuration
+app.crypto.master-key=${CRYPTO_MASTER_KEY:QmxvY2tjaGFpbjIwMjVTZWN1cml0eVByaXZhdGVLZXlGb3JQZXJzb25hbERhdGFFbmNyeXB0aW9u}
+app.crypto.algorithm=AES/GCM/NoPadding
+app.crypto.key-length=256
+app.crypto.iv-length=12
+app.crypto.tag-length=128

--- a/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
+++ b/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
@@ -60,6 +60,26 @@
         LIMIT 1
     </select>
 
+    <select id="findDailyTradeSummary"  resultMap="dailyTradeSummaryResultMap">
+        SELECT
+            trade_date,
+            MAX(CASE WHEN rn = 1 THEN trade_price_per_share END) AS close_price,
+            SUM(total_volume) AS total_volume
+        FROM (
+                 SELECT
+                     DATE(t.created_at) AS trade_date,
+             t.trade_price_per_share,
+             t.trade_count AS total_volume,
+             ROW_NUMBER() OVER (PARTITION BY DATE(t.created_at) ORDER BY t.created_at DESC) AS rn
+        FROM TRADES t
+            JOIN ORDER_BOOKS ob ON t.buy_order_id = ob.order_id OR t.sell_order_id = ob.order_id
+        WHERE ob.funding_id = #{fundingId}
+          AND t.created_at BETWEEN #{startDate} AND DATE_ADD(#{endDate}, INTERVAL 1 DAY)
+            ) AS daily_trades_with_rn
+        GROUP BY trade_date
+        ORDER BY trade_date ASC
+    </select>
+
     <resultMap id="tradeMap" type="org.bobj.trade.domain.TradeVO">
         <id property="tradeId" column="trade_id"/>
         <result property="buyOrderId" column="buy_order_id"/>
@@ -69,6 +89,12 @@
         <result property="tradeCount" column="trade_count"/>
         <result property="tradePricePerShare" column="trade_price_per_share"/>
         <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <resultMap id="dailyTradeSummaryResultMap" type="org.bobj.trade.dto.DailyTradeHistoryDTO">
+        <result property="date" column="trade_date"/>
+        <result property="closingPrice" column="close_price"/>
+        <result property="volume" column="total_volume"/>
     </resultMap>
 
 </mapper>

--- a/src/test/java/org/bobj/config/RootConfigTest.java
+++ b/src/test/java/org/bobj/config/RootConfigTest.java
@@ -1,4 +1,4 @@
-package org.example.config;
+package org.bobj.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
특정 매물(property)의 체결 내역을 조회하여 시세 그래프를 그리기 위한 API 구현

## 🔧 작업 내용
- 특정 매물 ID를 기반으로 체결 내역을 조회하는 API 설계 및 구현
- 조회된 체결 데이터를 체결 시간 순으로 정렬하여 반환
- 응답에 체결 가격(가격 변화) 및 거래량 정보 포함

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #44
