### PR TITLE
[FEAT] 펀딩 성공 시 보유주수 테이블에 반영하는 배치 작업 구현

### DIFF
--- a/src/main/java/org/bobj/config/AsyncConfig.java
+++ b/src/main/java/org/bobj/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package org.bobj.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "shareDistributionExecutor")
+    public TaskExecutor shareDistributionExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("share-distributor-");
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         "org.bobj.funding.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
-@Import({SwaggerConfig.class,
+@Import({
         AppConfig.class,
         OAuth2ClientConfig.class
 })

--- a/src/main/java/org/bobj/config/WebConfig.java
+++ b/src/main/java/org/bobj/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     // 루트 설정 클래스 (DB, 보안 등 전역 설정)
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[]{RootConfig.class};
+        return new Class[]{RootConfig.class,  AsyncConfig.class };
     }
 
 

--- a/src/main/java/org/bobj/funding/event/ShareDistributionEvent.java
+++ b/src/main/java/org/bobj/funding/event/ShareDistributionEvent.java
@@ -1,0 +1,10 @@
+package org.bobj.funding.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ShareDistributionEvent {
+    private final Long fundingId;
+}

--- a/src/main/java/org/bobj/funding/listener/ShareDistributionEventListener.java
+++ b/src/main/java/org/bobj/funding/listener/ShareDistributionEventListener.java
@@ -1,0 +1,25 @@
+package org.bobj.funding.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bobj.funding.event.ShareDistributionEvent;
+import org.bobj.funding.service.ShareDistributionService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShareDistributionEventListener {
+
+    private final ShareDistributionService shareDistributionService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleShareDistribution(ShareDistributionEvent event) {
+        log.info("[지분 분배 시작] 펀딩 ID: {}", event.getFundingId());
+        shareDistributionService.distributeSharersAsync(event.getFundingId());
+    }
+}

--- a/src/main/java/org/bobj/funding/service/ChunkExecutorService.java
+++ b/src/main/java/org/bobj/funding/service/ChunkExecutorService.java
@@ -1,0 +1,39 @@
+package org.bobj.funding.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.share.domain.ShareVO;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ChunkExecutorService {
+    private final ChunkInsertService chunkInsertService;
+
+//    private final ShareFailureRepository shareFailureRepository;
+
+
+    @Async("shareDistributionExecutor")
+    public CompletableFuture<Void> distributeChunkAsync(List<ShareVO> chunk, int chunkIndex){
+       try{
+           chunkInsertService.insertChunkTransactional(chunk);
+           log.info("청크 {} 주식 배분 완료(size:{})", chunkIndex, chunk.size());
+       }catch (Exception e) {
+           log.error("청크 {} 주식 배분 실패 - error: {}", chunkIndex, e.getMessage(), e);
+//           saveFailures(chunk, e.getMessage());
+       }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    //실패한 청크 처리 - DB에 저장할 것인지 추후 고민
+//    private void saveFailures(List<ShareVO> chunk, String reason){
+//        List<ShareFa>
+//    }
+
+}

--- a/src/main/java/org/bobj/funding/service/ChunkInsertService.java
+++ b/src/main/java/org/bobj/funding/service/ChunkInsertService.java
@@ -1,0 +1,30 @@
+package org.bobj.funding.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.share.domain.ShareVO;
+import org.bobj.share.mapper.ShareMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ChunkInsertService { // 청크 크기로 나누어진 ShareVO 리스트 DB에 삽입 - 트랜잭션
+
+    private final ShareMapper shareMapper;
+
+    @Transactional
+    public void insertChunkTransactional(List<ShareVO> chunk){
+        try{
+            int inserted = shareMapper.insertSharesBatch(chunk);
+            log.debug("DB에 {}건 insert 성공", inserted);
+        }catch(Exception e){
+            log.error("DB insert 중 예외 발생 - 청크 크기 : {}, 에러 {}", chunk.size(), e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/bobj/funding/service/ShareDistributionService.java
+++ b/src/main/java/org/bobj/funding/service/ShareDistributionService.java
@@ -1,0 +1,84 @@
+package org.bobj.funding.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.funding.domain.FundingOrderVO;
+import org.bobj.funding.mapper.FundingOrderMapper;
+import org.bobj.share.domain.ShareVO;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ShareDistributionService {
+
+    private final FundingOrderMapper fundingOrderMapper;
+    private final ChunkExecutorService chunkExeucutorService;
+
+    private static final int CHUNK_SIZE = 1000;
+
+   @Async("shareDistributionExecutor")
+    public void distributeSharersAsync(Long fundingId) {
+       long start = System.currentTimeMillis(); // 시작 시간 측정
+       log.info("주식 배분 시작 - fundingId: {}", fundingId);
+
+        try {
+            //펀딩에 참여자 펀딩 주문 조회
+            List<FundingOrderVO> orders = fundingOrderMapper.findAllOrdersByFundingId(fundingId);
+
+            log.debug("총 {} 명의 참가자", orders.size());
+
+            List<ShareVO> shares = orders.stream()
+                    .map(order -> ShareVO.builder()
+                            .userId(order.getUserId())
+                            .fundingId(order.getFundingId())
+                            .shareCount(order.getShareCount())
+                            .averageAmount(order.getOrderPrice().divide(BigDecimal.valueOf(order.getShareCount())))
+                            .build())
+                    .toList();
+
+            List<List<ShareVO>> chunks = partition(shares, CHUNK_SIZE);
+            log.info("총 {} 개의 청크로 분할 완료", chunks.size());
+
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+
+            for(int i=0;i<chunks.size();i++){
+                List<ShareVO> chunk = chunks.get(i);
+
+                log.debug("청크 {} 시작 (size:{})", i+1, chunk.size());
+
+//                chunkExeucutorService.distributeChunkAsync(chunk, i+1);
+                futures.add(chunkExeucutorService.distributeChunkAsync(chunk, i + 1));
+            }
+
+            // 모든 비동기 작업 완료 대기
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        }catch(Exception e){
+            log.error("주식 배분 중 치명적인 오류 발생 - fundingId :{}, error: {}", fundingId, e.getMessage(), e);
+        } finally {
+            long end = System.currentTimeMillis();
+            log.info("✅ 지분 분배 완료 - 총 처리 시간: {} ms", (end - start));
+        }
+
+    }
+
+    private <T> List<List<T>> partition(List<T> list, int size) { //청크 단위로 펀딩 주문 데이터 분할
+        List<List<T>> partitions = new ArrayList<>();
+
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+
+        return partitions;
+    }
+
+}

--- a/src/main/java/org/bobj/share/mapper/ShareMapper.java
+++ b/src/main/java/org/bobj/share/mapper/ShareMapper.java
@@ -30,4 +30,6 @@ public interface ShareMapper {
 
     int countSharesByUserId(@Param("userId") Long userId);
 
+    //주식 데이터 배치 삽입
+    int insertSharesBatch(List<ShareVO> shares);
 }

--- a/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
@@ -103,7 +103,6 @@
                created_at
         FROM funding_order
         WHERE funding_id = #{fundingId}
-          AND status = 'PENDING'
     </select>
 
     <!-- 펀딩 ID에 해당하는 모든 주문 상태 변경 -->

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -118,6 +118,14 @@
             s.share_id ASC  LIMIT #{limit} OFFSET #{offset}
     </select>
 
+    <insert id="insertSharesBatch" parameterType="java.util.List">
+        INSERT INTO shares (user_id, funding_id, share_count, average_amount)
+        VALUES
+        <foreach collection="list" item="item" separator=",">
+            (#{item.userId}, #{item.fundingId}, #{item.shareCount}, #{item.averageAmount})
+        </foreach>
+    </insert>
+
     <resultMap id="shareResponseDTOMap" type="org.bobj.share.dto.response.ShareResponseDTO">
         <id property="shareId" column="s_share_id"/>
         <result property="userId" column="s_user_id"/>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
펀딩이 목표 금액을 달성하여 종료되면, 참여자들에게 주식을 분배하는 비동기 배치 작업을 수행하도록 구현했습니다.

## 🔧 작업 내용
- 펀딩 종료 시 `ShareDistributionEvent` 발행
- 이벤트 리스너에서 비동기 지분 분배 시작 (`@Async`)
- `FundingOrderService` → `ShareDistributionService` → `ChunkExecutorService` → `ChunkInsertService` 구조
- 1,000건 단위 청크 처리 및 병렬 실행
- 총 처리 시간 로깅 기능 포함
-
## ✅ 체크리스트
- [x] 1만 건 데이터로 테스트 완료
- [x] 청크별 insert 작업 정상 처리 확인

## 📝 기타 참고 사항
- `ThreadPoolTaskExecutor` 설정: core 4, max 8, queue 100\
-  실패된 청크 처리에 대한 로직 구현 필요

## 📎 관련 이슈
Close #87
