### PR TITLE
Feature/#63

### DIFF
--- a/src/main/java/org/bobj/common/constants/ErrorCode.java
+++ b/src/main/java/org/bobj/common/constants/ErrorCode.java
@@ -31,7 +31,17 @@ public enum ErrorCode {
 
     // 500 ERROR
     GPT_API_ERROR(HttpStatus.BAD_GATEWAY, "S001", "요약 생성 중 오류가 발생했습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S999", "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S999", "서버 오류가 발생했습니다."),
+
+    // 📦 결제 오류 (Payment)
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P001", "결제 금액이 일치하지 않습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P002", "결제 정보가 존재하지 않습니다."),
+    PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "P003", "결제가 완료되지 않았습니다."),
+    PAYMENT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "P004", "이미 처리된 결제입니다."),
+    PAYMENT_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "P005", "결제 요청 내역이 존재하지 않습니다.");
+
+
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/bobj/config/MvcConfig.java
+++ b/src/main/java/org/bobj/config/MvcConfig.java
@@ -17,5 +17,7 @@ public class MvcConfig implements WebMvcConfigurer {
         registry
             .addResourceHandler("/webjars/**")
             .addResourceLocations("classpath:/META-INF/resources/webjars/");
+
+
     }
 }

--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -32,7 +32,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         "org.bobj.trade.mapper",
         "org.bobj.point.mapper",
         "org.bobj.user.mapper",
-        "org.bobj.funding.mapper"})
+        "org.bobj.funding.mapper",
+        "org.bobj.payment.mapper"})
 @ComponentScan(basePackages = "org.bobj")
 @EnableTransactionManagement
 @Import({

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -3,6 +3,7 @@ package org.bobj.config;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
@@ -21,7 +22,9 @@ import org.springframework.web.servlet.view.JstlView;
         "org.bobj.funding.controller",
         "org.bobj.user.controller",
         "org.bobj.orderbook.controller",
-        "org.bobj.funding.controller",})
+        "org.bobj.point.controller",
+        "org.bobj.payment.controller"})
+
 public class ServletConfig implements WebMvcConfigurer {
 
     @Override
@@ -41,6 +44,11 @@ public class ServletConfig implements WebMvcConfigurer {
         // 컨트롤러에서 인덱스라는 뷰 이름을 리턴한 경우
         // WEB-INF/views/ + view 이름 + .jsp
         registry.viewResolver(bean);
+    }
+
+    @Override
+    public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
+        configurer.enable(); // DispatcherServlet이 못 처리한 요청은 서블릿 컨테이너가 처리하게 위임
     }
 
 

--- a/src/main/java/org/bobj/payment/domain/PaymentVO.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentVO.java
@@ -1,24 +1,19 @@
 package org.bobj.payment.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class PaymentVO {
-    private Long paymentId;
+    private String impUid;
+    private String merchantUid;
     private Long userId;
     private BigDecimal amount;
     private PaymentStatus status;
-    private String pgTid;
-    private String qrUrl;
-    private LocalDateTime createdAt;
-    private LocalDateTime endAt;
+    private LocalDateTime paidAt;
+//    private LocalDateTime createdAt;
 }

--- a/src/main/java/org/bobj/payment/dto/PortOnePaymentResponse.java
+++ b/src/main/java/org/bobj/payment/dto/PortOnePaymentResponse.java
@@ -1,0 +1,36 @@
+package org.bobj.payment.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import lombok.Data;
+
+@Data
+public class PortOnePaymentResponse {
+    private int code;
+    private String message;
+    private PaymentData response;
+
+    @Data
+    public static class PaymentData{
+        @JsonProperty("imp_uid")
+        private String impUid;
+
+        @JsonProperty("merchant_uid")
+        private String merchantUid;
+
+        private int amount;
+
+        private String status;
+
+        @JsonProperty("pay_method")
+        private String payMethod;
+
+        @JsonProperty("paid_at")
+        private long paidAt;
+
+    }
+
+
+
+}

--- a/src/main/java/org/bobj/payment/exception/PaymentException.java
+++ b/src/main/java/org/bobj/payment/exception/PaymentException.java
@@ -1,0 +1,13 @@
+package org.bobj.payment.exception;
+
+import org.bobj.common.constants.ErrorCode;
+import org.bobj.common.exception.CustomException;
+import org.springframework.jdbc.support.SQLErrorCodes;
+
+public class PaymentException extends CustomException {
+
+    public PaymentException(ErrorCode errorCode){
+        super(errorCode,errorCode.getStatus().value());
+    }
+
+}

--- a/src/main/java/org/bobj/payment/mapper/PaymentMapper.java
+++ b/src/main/java/org/bobj/payment/mapper/PaymentMapper.java
@@ -1,0 +1,17 @@
+package org.bobj.payment.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.bobj.payment.domain.PaymentVO;
+
+@Mapper
+public interface PaymentMapper {
+
+
+    boolean existsByImpUid(@Param("impUid") String impUid);
+
+    void save(PaymentVO paymentVO);
+
+    PaymentVO findByImpUid(@Param("impUid") String impUid);
+
+}

--- a/src/main/java/org/bobj/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/bobj/payment/repository/PaymentRepository.java
@@ -1,0 +1,24 @@
+package org.bobj.payment.repository;
+
+
+import lombok.RequiredArgsConstructor;
+import org.bobj.payment.domain.PaymentVO;
+import org.bobj.payment.mapper.PaymentMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepository {
+    private final PaymentMapper paymentMapper;
+
+    public boolean existsByImpUid(String impUid){
+        return paymentMapper.existsByImpUid(impUid);
+    }
+    public void save(PaymentVO paymentVO){
+        paymentMapper.save(paymentVO);
+    }
+    public PaymentVO findByImpUid(String impUid){
+        return paymentMapper.findByImpUid(impUid);
+    }
+
+}

--- a/src/main/java/org/bobj/payment/service/PaymentService.java
+++ b/src/main/java/org/bobj/payment/service/PaymentService.java
@@ -1,0 +1,117 @@
+package org.bobj.payment.service;
+
+
+import static org.bobj.payment.domain.PaymentStatus.FAILED;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.implementation.bytecode.Throw;
+import org.bobj.common.constants.ErrorCode;
+import org.bobj.payment.client.PortOneClient;
+import org.bobj.payment.domain.PaymentStatus;
+import org.bobj.payment.domain.PaymentVO;
+import org.bobj.payment.dto.PortOnePaymentResponse;
+import org.bobj.payment.dto.PortOnePaymentResponse.PaymentData;
+import org.bobj.payment.dto.VerifyRequestDto;
+import org.bobj.payment.exception.PaymentException;
+import org.bobj.payment.repository.PaymentRepository;
+import org.bobj.point.domain.PointChargeRequestVO;
+import org.bobj.point.service.PointChargeRequestService;
+import org.bobj.point.service.PointService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PortOneClient portOneClient;
+    private final PaymentRepository paymentRepository;
+    private final PointService pointService; // 포인트 적립 처리용
+    private final PointChargeRequestService pointChargeRequestService;
+
+
+    @Transactional
+    public void verifyPayment(Long userId, VerifyRequestDto requestDto) {
+        String impUid = requestDto.getImpUid();
+        BigDecimal requestAmount = requestDto.getAmount();
+        PaymentData paymentData = null;
+
+        try {
+            // 1. 포트원에서 결제 정보 조회
+            PortOnePaymentResponse response = portOneClient.getPaymentInfo(impUid);
+            paymentData = response.getResponse();
+
+            if (paymentData == null) {
+                throw new PaymentException(ErrorCode.PAYMENT_NOT_FOUND);
+            }
+
+            // 2. 요청 내역 조회 (merchant_uid 기준)
+            PointChargeRequestVO chargeRequest =
+                pointChargeRequestService.findByMerchantUid(paymentData.getMerchantUid());
+
+            if (chargeRequest == null) {
+                throw new PaymentException(ErrorCode.PAYMENT_REQUEST_NOT_FOUND);
+            }
+
+            // 3. 결제 금액 일치 확인
+            if (BigDecimal.valueOf(paymentData.getAmount()).compareTo(requestAmount) != 0) {
+                throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+            }
+
+            // 4. 결제 상태 확인
+            if (!"paid".equalsIgnoreCase(paymentData.getStatus())) {
+                throw new PaymentException(ErrorCode.PAYMENT_NOT_COMPLETED);
+            }
+
+            // 5. 중복 결제 방지
+            if (paymentRepository.existsByImpUid(impUid)) {
+                throw new PaymentException(ErrorCode.PAYMENT_ALREADY_PROCESSED);
+            }
+
+            // 6. 상태 업데이트 & 포인트 지급
+            chargeRequest.setStatus("PAID");
+            chargeRequest.setImpUid(impUid);
+            pointChargeRequestService.updateStatusToPaid(chargeRequest);
+
+            pointService.chargePoint(userId, requestAmount, impUid);
+
+            // 7. 결제 정보 저장
+            paymentRepository.save(PaymentVO.builder()
+                .impUid(impUid)
+                .merchantUid(paymentData.getMerchantUid())
+                .userId(userId)
+                .amount(BigDecimal.valueOf(paymentData.getAmount()))
+                .status(PaymentStatus.SUCCESS)
+                .paidAt(Instant.ofEpochSecond(paymentData.getPaidAt())
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime())
+                .build());
+
+        } catch (PaymentException e) {
+            // ❗검증 실패한 경우에도 로그 & 저장
+            log.error("[결제 실패] {} - {}", impUid, e.getErrorCode().name());
+
+            // 실패 정보도 저장 (중복 방지 필요)
+            if (!paymentRepository.existsByImpUid(impUid)) {
+                paymentRepository.save(PaymentVO.builder()
+                    .impUid(impUid)
+                    .merchantUid(paymentData != null ? paymentData.getMerchantUid() : null)
+                    .userId(userId)
+                    .amount(paymentData != null ? BigDecimal.valueOf(paymentData.getAmount()) : requestAmount)
+                    .status(FAILED)
+                    .paidAt(null)
+                    .build());
+            }
+
+            throw e; // 다시 던져서 ControllerAdvice에서 처리되도록
+        }
+    }
+
+
+
+}

--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -1,31 +1,31 @@
-//package org.bobj.point.controller;
-//
-//import io.swagger.annotations.*;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.log4j.Log4j2;
-//import org.bobj.common.exception.ErrorResponse;
-//import org.bobj.common.response.ApiCommonResponse;
-//import org.bobj.payment.dto.VerifyRequestDto;
-//import org.bobj.payment.service.PaymentService;
-//import org.bobj.point.domain.PointChargeRequestVO;
-//import org.bobj.point.service.PointChargeRequestService;
-//import org.bobj.point.util.MerchantUidGenerator;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//import java.math.BigDecimal;
-//import java.security.Principal;
-//
-//@RestController
-//@RequestMapping("/api/point")
-//@RequiredArgsConstructor
-//@Log4j2
-//@Api(tags = "포인트 충전 및 검증 API")
-//public class PointChargeRequestController {
-//
-//    private final PointChargeRequestService pointChargeRequestService;
-//    private final PaymentService paymentService;
-//
+package org.bobj.point.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.common.exception.ErrorResponse;
+import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.payment.dto.VerifyRequestDto;
+import org.bobj.payment.service.PaymentService;
+import org.bobj.point.domain.PointChargeRequestVO;
+import org.bobj.point.service.PointChargeRequestService;
+import org.bobj.point.util.MerchantUidGenerator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/point")
+@RequiredArgsConstructor
+@Log4j2
+@Api(tags = "포인트 충전 및 검증 API")
+public class PointChargeRequestController {
+
+    private final PointChargeRequestService pointChargeRequestService;
+    private final PaymentService paymentService;
+
 //    @PostMapping("/charge")
 //    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
 //    @ApiResponses(value = {
@@ -52,7 +52,47 @@
 //
 //        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
 //    }
-//
+
+    @PostMapping("/charge")
+    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<String>> createCharge(
+        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount
+        // Principal principal ← 제거
+    ) {
+        // TODO: 실제 배포 시 제거
+        Long userId = 1L; // 임시 테스트용 사용자 ID
+
+        String merchantUid = MerchantUidGenerator.generate(userId);
+
+        PointChargeRequestVO request = PointChargeRequestVO.builder()
+            .userId(userId)
+            .amount(amount)
+            .merchantUid(merchantUid)
+            .status("PENDING")
+            .build();
+
+        pointChargeRequestService.createChargeRequest(request);
+        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
+    }
+
+
+
+
+
+
+
+
+
+
+
+
 //    @PostMapping("/verify")
 //    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
 //    @ApiResponses(value = {
@@ -83,3 +123,27 @@
 //        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
 //    }
 //}
+
+    @PostMapping("/verify")
+    public ResponseEntity<?> verifyPayment(@RequestBody VerifyRequestDto dto) {
+        Long testUserId = 1L; // 실제 로그인 구현 전 테스트용 하드코딩
+
+        paymentService.verifyPayment(testUserId, dto);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
+    }
+
+
+    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
+        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
+        VerifyRequestDto requestDto,
+        Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
+
+        paymentService.verifyPayment(userId, requestDto);
+
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
+    }
+}

--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -1,0 +1,31 @@
+package org.bobj.point.controller;
+
+import io.swagger.annotations.ApiOperation;
+import java.security.Principal;
+import java.util.List;
+import java.util.function.LongPredicate;
+import lombok.RequiredArgsConstructor;
+import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.point.domain.PointTransactionVO;
+import org.bobj.point.service.PointService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/point")
+@RequiredArgsConstructor
+public class PointController {
+    private final PointService pointService;
+
+    @GetMapping("/transactions")
+    @ApiOperation(value = "포인트 입출금 내역 조회", notes = "로그인한 사용자의 포인트 입출금 트랜잭션 내역을 조회합니다.")
+    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactions(Principal principal){
+        Long userId = Long.parseLong(principal.getName());
+        List<PointTransactionVO> transactions = pointService.findTransactionsByUserId(userId);
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
+    }
+
+}

--- a/src/main/java/org/bobj/point/domain/PointTransactionType.java
+++ b/src/main/java/org/bobj/point/domain/PointTransactionType.java
@@ -1,5 +1,5 @@
 package org.bobj.point.domain;
 
 public enum PointTransactionType {
-    DEPOSIT, INVEST, TRADE_SALE, PAYOUT
+    DEPOSIT, INVEST, TRADE_SALE, PAYOUT//수익금 정산
 }

--- a/src/main/java/org/bobj/point/mapper/PointTransactionMapper.java
+++ b/src/main/java/org/bobj/point/mapper/PointTransactionMapper.java
@@ -1,0 +1,11 @@
+package org.bobj.point.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.bobj.point.domain.PointTransactionVO;
+
+@Mapper
+public interface PointTransactionMapper {
+    void insert(PointTransactionVO transaction);
+    List<PointTransactionVO> findByUserId(Long userId);
+}

--- a/src/main/java/org/bobj/point/repository/PointTransactionRepository.java
+++ b/src/main/java/org/bobj/point/repository/PointTransactionRepository.java
@@ -1,0 +1,24 @@
+package org.bobj.point.repository;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.bobj.point.domain.PointTransactionVO;
+import org.bobj.point.mapper.PointTransactionMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointTransactionRepository {
+    private final PointTransactionMapper pointTransactionMapper;
+
+    public void insert(PointTransactionVO transaction){
+        pointTransactionMapper.insert(transaction);
+    }
+
+
+    public List<PointTransactionVO> findByUserId(Long userId){
+        return pointTransactionMapper.findByUserId(userId);
+    }
+
+
+}

--- a/src/main/java/org/bobj/point/service/PointChargeRequestService.java
+++ b/src/main/java/org/bobj/point/service/PointChargeRequestService.java
@@ -29,6 +29,7 @@ public class PointChargeRequestService {
 
     /**
      * 결제 성공 후 상태 업데이트 (PAID 상태로)
+     * PointChargeRequestVO의 상태를 PAID로 바꾸고 impUid도 함께 저장
      */
     @Transactional
     public void updateStatusToPaid(PointChargeRequestVO request) {

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -1,16 +1,24 @@
 package org.bobj.point.service;
 
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.bobj.point.domain.PointTransactionType;
+import org.bobj.point.domain.PointTransactionVO;
 import org.bobj.point.domain.PointVO;
 import org.bobj.point.repository.PointRepository;
+import org.bobj.point.repository.PointTransactionRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PointService {
+
     private final PointRepository pointRepository;
+    private final PointTransactionRepository pointTransactionRepository;
 
     public PointVO findById(Long pointId) {
         return pointRepository.findById(pointId);
@@ -37,4 +45,45 @@ public class PointService {
     }
 
 
+    public List<PointTransactionVO> findTransactionsByUserId(Long userId) {
+        return pointTransactionRepository.findByUserId(userId);
+    }
+
+
+
+    /**
+     *
+     * 결제 성공 후 포인트 적립 및 트랜잭션 기록
+     * @param userId 사용자 ID
+     * @param amount 충전 금액
+     * @param impUid 결제 고유 ID (PortOne)
+     */
+    @Transactional
+    public void chargePoint(Long userId, BigDecimal amount, String impUid) {
+        // 1. 유저의 포인트 정보 조회 (FOR UPDATE)
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+
+        // 2. 없으면 새로 생성
+        if (point == null) {
+            point = PointVO.builder()
+                .userId(userId)
+                .amount(amount)
+                .build();
+            pointRepository.insert(point);
+        } else {
+            // 3. 있으면 잔액 누적
+            point.setAmount(point.getAmount().add(amount));
+            pointRepository.update(point);
+        }
+
+        // 4. 트랜잭션 기록 (DEPOSIT)
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(PointTransactionType.DEPOSIT)
+            .amount(amount)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        pointTransactionRepository.insert(tx);
+    }
 }

--- a/src/main/resources/org/bobj/payment/mapper/PaymentMapper.xml
+++ b/src/main/resources/org/bobj/payment/mapper/PaymentMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.payment.mapper.PaymentMapper">
+
+
+  <resultMap id="PaymentResultMap" type="org.bobj.payment.domain.PaymentVO">
+    <result property="impUid" column="imp_uid"/>
+    <result property="merchantUid" column="merchant_uid"/>
+    <result property="userId" column="user_id"/>
+    <result property="amount" column="amount"/>
+    <result property="status" column="status" javaType="org.bobj.payment.domain.PaymentStatus"/>
+    <result property="paidAt" column="paid_at"/>
+  </resultMap>
+
+  <!-- imp_uid 존재 여부 확인 -->
+  <select id="existsByImpUid" resultType="boolean">
+    SELECT EXISTS(
+    SELECT 1
+    FROM payment
+    WHERE imp_uid = #{impUid}
+    )
+  </select>
+
+  <insert id="save">
+    INSERT INTO payment (imp_uid, merchant_uid, user_id, amount, status, paid_at)
+    VALUES (#{impUid}, #{merchantUid}, #{userId}, #{amount}, #{status}, #{paidAt})
+  </insert>
+
+  <!-- ✅ resultMap 적용 -->
+  <select id="findByImpUid" resultMap="PaymentResultMap">
+    SELECT *
+    FROM payment
+    WHERE imp_uid = #{impUid}
+  </select>
+
+</mapper>

--- a/src/main/resources/org/bobj/point/mapper/PointChargeRequestMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointChargeRequestMapper.xml
@@ -4,11 +4,25 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.point.mapper.PointChargeRequestMapper">
 
-  <insert id="insert" parameterType="PointChargeRequestVO" 
+  <insert id="insert" parameterType="org.bobj.point.domain.PointChargeRequestVO"
     useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO point_charge_request (
+      user_id,
+      amount,
+      merchant_uid,
+      status,
+      created_at
+    ) VALUES (
+               #{userId},
+               #{amount},
+               #{merchantUid},
+               #{status},
+               NOW()
+             )
   </insert>
-  
-  <select id="findByMerchantUid" parameterType="String" resultType="PointChargeRequestVO">>
+
+
+  <select id="findByMerchantUid" parameterType="String" resultType="PointChargeRequestVO">
     SELECT *
     FROM point_charge_request
     where merchant_uid = #{merchantUid}

--- a/src/main/resources/org/bobj/point/mapper/PointMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointMapper.xml
@@ -20,11 +20,12 @@
     where user_id = #{userId} FOR UPDATE;
   </select>
 
-  <insert id="insert" parameterType="PointVO">
-    insert into point(user_id,amount,created_at) //db 칼럼
+  <insert id="insert" parameterType="PointVO" useGeneratedKeys="true" keyProperty="pointId">
+    insert into point(user_id, amount, updated_at)
     VALUES (#{userId}, #{amount}, NOW())
   </insert>
-  
+
+
   <update id="update" parameterType="PointVO">
     update point
     set amount = #{amount},
@@ -33,7 +34,7 @@
   </update>
 
   <delete id="delete">
-    DELETE FROM point WHERE point_id = #{pointId}}
+    DELETE FROM point WHERE point_id = #{pointId}
   </delete>
 
 </mapper>

--- a/src/main/resources/org/bobj/point/mapper/PointTransactionMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointTransactionMapper.xml
@@ -3,4 +3,31 @@
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.point.mapper.PointTransactionMapper">
+
+  <insert id="insert" parameterType="org.bobj.point.domain.PointTransactionVO">
+        INSERT INTO point_transaction(
+                                    point_id,
+                                    type,
+                                    amount,
+                                    created_at
+        )
+        VALUES (
+                 #{pointId},
+                 #{type},
+                 #{amount},
+                 NOW()
+        )
+  </insert>
+
+
+
+  <select id="findByUserId" resultType="org.bobj.point.domain.PointTransactionVO">
+        SELECT pt.*
+        FROM point_transaction pt
+        JOIN points p ON pt.point_id = p.point_id
+        WHERE p.user_id = #{userId}
+        ORDER BY pt.created_at DESC
+  </select>
+
+
 </mapper>

--- a/src/main/webapp/test-payment.html
+++ b/src/main/webapp/test-payment.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>PortOne 테스트 결제</title>
+  <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+<h2>포트원 결제 테스트</h2>
+<button onclick="requestPay()">결제하기</button>
+
+<script>
+  var IMP = window.IMP;
+  IMP.init("imp18670123"); // ✅ 고객사 식별코드 제대로 사용 중!
+
+  function requestPay() {
+
+    const merchant_uid = "point_20250804001510_1_fba1d505"; // DB와 일치
+
+    IMP.request_pay({
+      pg: "kakaopay.TC0ONETIME",
+      pay_method: "card",
+      merchant_uid: merchant_uid,
+      name: "반의 반 집 포인트 충전",
+      amount: 5000,
+      buyer_email: "test@example.com",
+      buyer_name: "홍길동",
+      buyer_tel: "010-1234-5678",
+      buyer_addr: "서울특별시",
+      buyer_postcode: "12345"
+    }, function (rsp) {
+      if (rsp.success) {
+        alert("결제 성공! 서버에 결제 정보 전송 중...");
+        axios.post("http://localhost:8080/api/point/verify", {
+          impUid: rsp.imp_uid,
+          amount: 5000
+        }, {
+          headers: {
+            "Content-Type": "application/json"
+            // "Authorization": "Bearer your-access-token" // 필요 시 추가
+          }
+        }).then(res => {
+          alert("서버 검증 완료: " + JSON.stringify(res.data));
+        }).catch(err => {
+          alert("서버 검증 실패: " + err.response?.data?.message || "에러 발생");
+        });
+      } else {
+        alert("결제 실패: " + rsp.error_msg);
+      }
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
---
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
결제 검증 이후 포인트 충전 요청 상태를 SUCCESS로 변경하고, 해당 유저의 포인트 적립 및 트랜잭션 내역을 기록하는 기능 구현

## 🔧 작업 내용
- 결제 검증 이후 `point_charge_request` 상태 업데이트
- 포인트 적립 처리 로직 `PointService`에 추가
- 포인트 트랜잭션 기록 기능 및 관련 Mapper/Repository 추가
- 포인트 보유 내역 조회 개선
- 관련 MyBatis 설정 및 매핑 XML 수정

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
- [x] 결제 성공 시 포인트 적립 확인
- [x] 중복 결제 방지 로직 정상 작동

## 📝 기타 참고 사항
- 웹훅 없이 결제 성공 직후 프론트에서 `/api/point/verify` 호출로 후처리 진행 중
- 향후 웹훅 추가 시 병합 구조 재정비 고려

## 📎 관련 이슈
Close #63
