### PR TITLE
[FIX] #98 remove unintended 'name' query param from Swagger UI

### DIFF
--- a/src/main/java/org/bobj/config/SwaggerConfig.java
+++ b/src/main/java/org/bobj/config/SwaggerConfig.java
@@ -35,6 +35,7 @@ public class SwaggerConfig {
             .apis(RequestHandlerSelectors.basePackage("org.bobj"))
             .paths(PathSelectors.any())
             .build()
+            .ignoredParameterTypes(java.security.Principal.class)
             .securitySchemes(Collections.singletonList(apiKey()))
 //            .securityContexts(Collections.singletonList(securityContext()));
             .securityContexts(Collections.emptyList()); // 🔥 아무 경로에도 인증 적용 안함

--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PointController {
     private final PointService pointService;
-
     @GetMapping("/transactions")
     @ApiOperation(value = "포인트 입출금 내역 조회", notes = "로그인한 사용자의 포인트 입출금 트랜잭션 내역을 조회합니다.")
     public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactions(Principal principal){


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Swagger에서 `Principal` 객체로 인해 잘못 노출되던 `name` 쿼리 파라미터를 제거했습니다.

## 🔧 작업 내용
- Swagger 설정에서 `.ignoredParameterTypes(Principal.class)` 추가
- `/api/point/transactions`에 표시되던 `name` 파라미터 제거
- Swagger UI 문서와 실제 API 요청 간 불일치 해결

## ✅ 체크리스트
- [x] 테스트 ( Swagger 현재 인증 로그인 불가)

## 📎 관련 이슈
Close #98
