### PR TITLE
[FEAT] implement accurate point balance calculation logic

### DIFF
--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -27,4 +27,14 @@ public class PointController {
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
     }
 
+
+    @GetMapping("/balance")
+    @ApiOperation(value = "현재 포인트 보유량 조회", notes = "로그인한 사용자의 현재 포인트 보유량을 반환합니다.")
+    public ResponseEntity<ApiCommonResponse<Long>> getPointBalance(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        Long balance = pointService.getTotalPoint(userId);
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
+    }
+
+
 }

--- a/src/main/java/org/bobj/point/domain/PointTransactionType.java
+++ b/src/main/java/org/bobj/point/domain/PointTransactionType.java
@@ -1,5 +1,30 @@
 package org.bobj.point.domain;
 
+/**
+ * 포인트 트랜잭션 유형을 정의하는 enum
+ * 각 항목은 잔액 계산 시 더할지 뺄지를 isPositive로 판단함
+ */
 public enum PointTransactionType {
-    DEPOSIT, INVEST, TRADE_SALE, PAYOUT//수익금 정산
+
+    DEPOSIT(true),     // 💰 사용자가 직접 충전한 포인트 → 잔액에 더함
+    INVEST(false),     // 🏗️ 펀딩 등에 투자로 사용된 포인트 → 잔액에서 차감
+    TRADE_SALE(true),  // 🏷️ 지분 매각으로 얻은 수익 → 잔액에 더함
+    PAYOUT(true),      // 💵 프로젝트 수익 정산 → 잔액에 더함
+    WITHDRAW(false),   // 🔻 실제 출금된 환급 포인트 → 잔액에서 차감
+    REFUND(true),      // 🔁 투자 실패/환급 실패 등으로 복원된 포인트 → 잔액에 더함
+    CANCEL(true);      // 🚫 주문 취소로 되돌아온 포인트 → 잔액에 더함
+
+    private final boolean isPositive;
+
+    PointTransactionType(boolean isPositive) {
+        this.isPositive = isPositive;
+    }
+
+    /**
+     * 포인트 금액에 부호를 적용하는 유틸 메서드
+     * 양수 유형이면 그대로, 음수 유형이면 음수로 반환
+     */
+    public long applySign(long amount) {
+        return isPositive ? amount : -amount;
+    }
 }

--- a/src/main/java/org/bobj/point/mapper/PointMapper.java
+++ b/src/main/java/org/bobj/point/mapper/PointMapper.java
@@ -19,4 +19,9 @@ public interface PointMapper {
     void delete(@Param("pointId") Long pointId);
 
     PointVO findByUserIdForUpdate(@Param("userId") Long userId);
+
+
+    Long findTotalPointByUserId(Long userId);
+
+
 }

--- a/src/main/java/org/bobj/point/repository/PointRepository.java
+++ b/src/main/java/org/bobj/point/repository/PointRepository.java
@@ -36,4 +36,9 @@ public class PointRepository {
     public PointVO findByUserIdForUpdate(Long userId){
         return pointMapper.findByUserIdForUpdate(userId);
     }
+
+    public Long findTotalPointByUserId(Long userId) {
+        return pointMapper.findTotalPointByUserId(userId);
+    }
+
 }

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -86,4 +86,9 @@ public class PointService {
 
         pointTransactionRepository.insert(tx);
     }
+
+    public Long getTotalPoint(Long userId) {
+        // 포인트 테이블에서 현재 보유 포인트 계산
+        return pointRepository.findTotalPointByUserId(userId);
+    }
 }

--- a/src/main/resources/org/bobj/point/mapper/PointMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointMapper.xml
@@ -37,4 +37,21 @@
     DELETE FROM point WHERE point_id = #{pointId}
   </delete>
 
+  <select id="findTotalPointByUserId" resultType="long" parameterType="long">
+    SELECT COALESCE(SUM(
+                      CASE
+                        WHEN type IN ('DEPOSIT', 'TRADE_SALE', 'PAYOUT', 'REFUND', 'CANCEL') AND status = 'COMPLETED' THEN amount
+                        WHEN type IN ('INVEST', 'WITHDRAW') AND status = 'COMPLETED' THEN -amount
+                        ELSE 0
+                        END
+                    ), 0)
+    FROM point_transactions
+    WHERE user_id = #{userId}
+  </select>
+
+
+
+
+
+
 </mapper>


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사용자의 현재 포인트 보유량을 정확하게 계산하기 위한 잔액 계산 로직을 구현했습니다.  
포인트 트랜잭션 타입 및 상태를 반영하여 실제 사용 가능한 포인트를 정산합니다.

## 🔧 작업 내용
- PointTransactionType enum 확장 (WITHDRAW, REFUND, CANCEL 등 추가)
- 각 트랜잭션 유형에 따른 양/음수 처리 로직 구현 (`applySign`)
- MyBatis 쿼리에서 type + status 조합 기반 잔액 계산 쿼리 작성
- `/api/point/balance` API 구현 (Principal 기반 사용자 식별)
- Swagger 테스트 정상 작동 확인 불가 -> 현재 jwt 토큰 사용할 수 없음

## ✅ 체크리스트
- [ ] 테스트 (Postman, Swagger)

## 📝 기타 참고 사항
- 향후 환불 요청 기능은 별도 이슈에서 구현 예정
- `status = 'COMPLETED'` 외 상태는 잔액 계산에서 제외됨

## 📎 관련 이슈
Close #100
