### PR TITLE
[FEAT] 레디스 설정 및 주문 체결 레디스 큐 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,11 @@ dependencies {
     implementation "org.springframework:spring-messaging:${springVersion}"
     implementation "org.springframework.integration:spring-integration-stomp:5.5.20"
 
+    // Redis
+   // implementation "org.springframework.data:spring-data-redis:2.7.20" // Spring Data Redis
+    //implementation "io.lettuce:lettuce-core:6.3.1"// Redis 클라이언트 (Lettuce)
+    implementation "org.springframework.data:spring-data-redis:2.6.6"
+    implementation "io.lettuce:lettuce-core:6.2.4.RELEASE"
 
 // xml내 한글 처리
     implementation 'xerces:xercesImpl:2.12.2'

--- a/src/main/java/org/bobj/config/RedisConfig.java
+++ b/src/main/java/org/bobj/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package org.bobj.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@PropertySource("classpath:/application.properties")
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // redis 연결 정보(host, port, password)
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(
+                host, port);
+//        redisStandaloneConfiguration.setPassword(password);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        // 데이터를 받아 올 RedisConnection 설정
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+}

--- a/src/main/java/org/bobj/config/WebConfig.java
+++ b/src/main/java/org/bobj/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     // 루트 설정 클래스 (DB, 보안 등 전역 설정)
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[]{RootConfig.class,  AsyncConfig.class };
+        return new Class[]{RootConfig.class,  AsyncConfig.class, RedisConfig.class};
     }
 
 

--- a/src/main/java/org/bobj/funding/mapper/FundingMapper.java
+++ b/src/main/java/org/bobj/funding/mapper/FundingMapper.java
@@ -57,4 +57,6 @@ public interface FundingMapper {
 
     // 펀딩 완료 후 2년된 매물 찾기
     List<FundingSoldResponseDTO> findSoldFundingIds();
+
+    List<Long> findAllFundingIds();
 }

--- a/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
+++ b/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
@@ -38,9 +38,11 @@ public interface FundingOrderMapper {
     // 펀딩 ID에 해당하는 모든 주문 조회
     List<FundingOrderVO> findAllOrdersByFundingId(Long fundingId);
 
+
     // 펀딩 ID에 해당하는 펀딩 주문 ID 리스트 조회
     List<Long> findFundingOrderIdsByFundingId(@Param("fundingId") Long fundingId);
 
     // 펀딩 주문 ID 리스트에 해당하는 펀딩 주문 데이터 status 수정
     void updateFundingOrderStatusToRefundedByOrderIds(@Param("orderIds") List<Long> orderIds);
+
 }

--- a/src/main/java/org/bobj/funding/service/FundingOrderService.java
+++ b/src/main/java/org/bobj/funding/service/FundingOrderService.java
@@ -74,6 +74,7 @@ public class FundingOrderService {
             fundingMapper.markAsEnded(fundingId);
             fundingOrderMapper.markOrdersAsSuccessByFundingId(fundingId);
 
+
             eventPublisher.publishEvent(new ShareDistributionEvent(fundingId));
 //            shareDistributionService.distributeSharersAsync(fundingId); // 참여자들에게 지분 삽입
         }

--- a/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
+++ b/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
@@ -1,0 +1,68 @@
+package org.bobj.order.consumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.funding.mapper.FundingMapper;
+import org.bobj.order.domain.OrderVO;
+import org.bobj.order.mapper.OrderMapper;
+import org.bobj.order.service.OrderMatchingService;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class OrderQueueConsumer {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final OrderMapper orderMapper;
+    private final OrderMatchingService orderMatchingService;
+    private final FundingMapper fundingMapper;
+
+    // 매 1초마다 Redis 큐에서 주문 ID 꺼내서 처리
+    @Scheduled(fixedDelay = 1000)
+    public void consumeOrders() {
+        for (Long fundingId : getTrackedFundingIds()) {
+            String queueKey = "order:queue:" + fundingId;
+            String processingQueueKey = "processing:order:queue:" + fundingId;
+
+            Object orderIdObj = redisTemplate.opsForList().rightPopAndLeftPush(queueKey, processingQueueKey);
+            if (orderIdObj == null) continue;
+            try {
+                Long orderId = Long.valueOf(orderIdObj.toString());
+                OrderVO order = orderMapper.get(orderId);
+
+                if (order == null) {
+                    throw new IllegalArgumentException("주문 ID 찾을 수 없음: " + orderId);
+                }
+
+                int remainingCount = orderMatchingService.processOrderMatching(order);
+//                orderMatchingService.processOrderMatching(order);
+
+                if (remainingCount > 0) {
+                    // 아직 체결되지 않은 수량이 남아있으면 다시 큐에 넣기
+                    redisTemplate.opsForList().rightPush(queueKey, orderId); // FIFO 유지
+                    log.info("🔁 주문 일부 체결됨. 재큐잉 (orderId={}, remaining={})", orderId, remainingCount);
+                }
+
+                // 처리 완료 시 처리 중 큐에서 주문 ID 삭제
+                redisTemplate.opsForList().remove(processingQueueKey, 1, orderIdObj);
+
+                log.info("✅ 주문 처리 완료 (주문 ID: {})", orderId);
+            } catch (Exception e) {
+                log.error("❗ 주문 처리 실패: {}", e.getMessage());
+
+                // 처리 실패 시, 처리 중 큐에서 다시 원래 큐로 복귀
+                Object popped = redisTemplate.opsForList().rightPopAndLeftPush(processingQueueKey, queueKey);
+            }
+        }
+    }
+
+    private Long[] getTrackedFundingIds() {
+        List<Long> ids = fundingMapper.findAllFundingIds();
+        return ids.toArray(new Long[0]);
+    }
+}

--- a/src/main/java/org/bobj/order/producer/OrderQueueProducer.java
+++ b/src/main/java/org/bobj/order/producer/OrderQueueProducer.java
@@ -1,0 +1,19 @@
+package org.bobj.order.producer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderQueueProducer {
+
+    private static final String ORDER_QUEUE_PREFIX = "order:queue:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void pushOrder(Long fundingId, Long orderId) {
+        String key = ORDER_QUEUE_PREFIX + fundingId;
+        redisTemplate.opsForList().rightPush(key, orderId);
+    }
+}

--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -33,7 +33,7 @@ public class OrderMatchingService {
     private final OrderBookWebSocketService orderBookWebSocketService;
 
     @Transactional
-    public void processOrderMatching(OrderVO newOrder) {
+    public int processOrderMatching(OrderVO newOrder) {
 
         // 1. 매칭될 반대편 주문 조회
         // 신규 주문이 BUY 이면 SELL 주문을, SELL 이면 BUY 주문을 찾는다.
@@ -49,6 +49,8 @@ public class OrderMatchingService {
                 oppositeOrderType,
                 String.valueOf(newOrder.getOrderType())
         );
+
+        log.debug("🔍 매칭 대상 주문 수: {}", matchingOrders.size());
 
         // 3. 매칭 조건이 되는 주문과 체결 시도
         int remainingNewOrderCount = newOrder.getOrderShareCount(); // 신규 주문의 남은 수량
@@ -124,6 +126,8 @@ public class OrderMatchingService {
 
         // 모든 체결 처리 후 최종 호가창 업데이트를 웹소켓으로 푸시
         orderBookWebSocketService.publishOrderBookUpdate(newOrder.getFundingId());
+
+        return remainingNewOrderCount;
     }
 
     // 매수자 포인트 업데이트

--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -1,3 +1,4 @@
+
 package org.bobj.point.controller;
 
 import io.swagger.annotations.*;
@@ -53,6 +54,7 @@ public class PointChargeRequestController {
 //        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
 //    }
 
+
     @PostMapping("/charge")
     @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
     @ApiResponses(value = {
@@ -81,10 +83,6 @@ public class PointChargeRequestController {
 
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
     }
-
-
-
-
 
 
 
@@ -123,6 +121,7 @@ public class PointChargeRequestController {
 //        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
 //    }
 //}
+
 
     @PostMapping("/verify")
     public ResponseEntity<?> verifyPayment(@RequestBody VerifyRequestDto dto) {

--- a/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
@@ -205,6 +205,7 @@
         funding_end_date = NOW()
     WHERE funding_id = #{fundingId}
   </update>
+
   <!-- 펀딩 실패인 펀딩 ID 조회 -->
   <select id="findFailedFundingIds" resultType="java.lang.Long">
     <![CDATA[
@@ -234,4 +235,5 @@
     WHERE DATE(f.funding_end_date) = DATE(DATE_SUB(NOW(), INTERVAL 2 YEAR))
       AND f.status = 'ENDED';
   </select>
+
 </mapper>

--- a/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
@@ -65,8 +65,8 @@
       p.description,
       u.user_id,
       u.name,
-      u.email,
-      u.phone,
+--       u.email,
+--       u.phone,
       ph.photo_id,
       ph.property_id AS photo_property_id,
       ph.photo_url,
@@ -191,7 +191,11 @@
     WHERE funding_id = #{fundingId}
   </select>
 
-  <!-- 펀딩 주문 후 모집 금액 증가 -->
+    <select id="findAllFundingIds" resultType="java.lang.Long">
+      SELECT funding_id FROM fundings
+    </select>
+
+    <!-- 펀딩 주문 후 모집 금액 증가 -->
   <update id="increaseCurrentAmount">
     UPDATE fundings
     SET current_amount = current_amount + #{orderPrice}

--- a/src/test/java/org/bobj/config/RedisConfigTest.java
+++ b/src/test/java/org/bobj/config/RedisConfigTest.java
@@ -1,0 +1,62 @@
+package org.bobj.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = RedisConfig.class)
+@ActiveProfiles("test")
+class RedisConfigTest {
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired(required = false)
+    private PropertySourcesPlaceholderConfigurer configurer;
+
+    @Test
+    @DisplayName("RedisConnectionFactory가 정상적으로 주입된다.")
+    void testRedisConnectionFactory() {
+        assertNotNull(redisConnectionFactory, "RedisConnectionFactory가 null입니다.");
+
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        assertNotNull(connection, "Redis 연결이 실패했습니다.");
+        log.info("Redis 연결 성공: {}", connection);
+    }
+
+    @Test
+    @DisplayName("RedisTemplate이 정상적으로 생성된다.")
+    void testRedisTemplate() {
+        assertNotNull(redisTemplate, "RedisTemplate이 null입니다.");
+        redisTemplate.opsForValue().set("testKey", "Hello Redis");
+        Object value = redisTemplate.opsForValue().get("testKey");
+        assertEquals("Hello Redis", value);
+        log.info("RedisTemplate 동작 확인: testKey = {}", value);
+    }
+
+//    @Test
+//    @DisplayName("PropertySourcesPlaceholderConfigurer가 정상 주입된다.")
+//    void testPropertySourcesPlaceholderConfigurer() {
+//        assertNotNull(configurer, "PropertySourcesPlaceholderConfigurer가 null입니다.");
+//        log.info("PropertySourcesPlaceholderConfigurer: {}", configurer.getClass().getSimpleName());
+//    }
+}


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Redis 기반 주문 큐를 도입하여 주문 체결 시 동시성 문제를 완화하고, 안정적인 체결 처리가 가능하도록 개선했습니다.

## 🔧 작업 내용

- RedisTemplate 기반 주문 큐 구성 (order:queue:{fundingId})
- 주문 요청 시 Redis 큐에 주문 정보 삽입 (OrderQueueProducer)
- @Scheduled 기반 Consumer가 주기적으로 큐에서 주문을 꺼내 매칭 처리
- 주문 체결 실패 또는 부분 체결 시, 미체결 수량을 다시 큐에 재등록
- 처리 중 예외 발생 시, 큐 복구 로직 포함
- Redis 설정 (RedisConfig) 추가: JSON 직렬화 및 호스트/포트 설정

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)
- 동시 주문 요청 시 체결 중복 여부 확인
- Redis 큐 상태 정상 동작 여부 확인

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #92
