### PR TITLE
[FEAT] #108 Add Redis configuration and register StringRedisTemplate …

### DIFF
--- a/src/main/java/org/bobj/config/RedisConfig.java
+++ b/src/main/java/org/bobj/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -42,6 +43,11 @@ public class RedisConfig {
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
     }
 
 }

--- a/src/main/java/org/bobj/redis/RedisTestController.java
+++ b/src/main/java/org/bobj/redis/RedisTestController.java
@@ -1,0 +1,21 @@
+package org.bobj.redis; // ← 경로에 맞게 수정
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+@RequiredArgsConstructor
+public class RedisTestController {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @GetMapping("/redis-test")
+    public String testRedis() {
+        redisTemplate.opsForValue().set("testKey", "hello redis", Duration.ofMinutes(1));
+        return redisTemplate.opsForValue().get("testKey");
+    }
+}


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가  
- [x] 🐛 버그 수정  
- [ ] ♻️ 리팩토링  
- [ ] 🧪 테스트 코드 추가  
- [ ] 📄 문서 수정  
- [ ] 기타

## 📌 개요
Spring Legacy 환경에서 StringRedisTemplate Bean 미등록으로 인한 의존성 주입 실패 문제 해결

## 🔧 작업 내용
- RedisConfig에 StringRedisTemplate Bean 수동 등록
- RedisConnectionFactory 및 RedisTemplate 설정 보완
- application.properties에서 host, port 설정 주입 처리

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)
- [ ] Redis 컨테이너 정상 연결 확인
- [ ] /redis-test 엔드포인트 응답 확인

## 📝 기타 참고 사항
- Spring Boot가 아닌 Legacy 프로젝트이므로 Bean 등록 필수
- Redis 연결 시 host는 docker-compose 서비스명(redis) 기준 사용

## 📎 관련 이슈
Close #108 
