### PR TITLE
[FEAT] implement point refund request API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'javax.inject:javax.inject:1'
     // @Resource 어노테이션을 사용하기 위해 추가한 의존성
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'javax.validation:validation-api:2.0.1.Final'
+
 
     // Spring Security
     implementation "org.springframework.security:spring-security-web:${springSecurityVersion}"

--- a/src/main/java/org/bobj/point/RefundRequestDto.java
+++ b/src/main/java/org/bobj/point/RefundRequestDto.java
@@ -1,0 +1,16 @@
+package org.bobj.point;
+
+
+import java.math.BigDecimal;
+import javax.validation.constraints.Min;
+import lombok.Getter;
+import javax.validation.constraints.NotNull;
+
+
+@Getter
+public class RefundRequestDto {
+
+    @NotNull(message = "환급 금액은 필수입니다.")
+    @Min(value = 1, message = "환급 금액은 최소 1원 이상이어야 합니다.")
+    private BigDecimal amount;
+}

--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -1,15 +1,22 @@
 package org.bobj.point.controller;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import java.security.Principal;
 import java.util.List;
 import java.util.function.LongPredicate;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.bobj.common.exception.ErrorResponse;
 import org.bobj.common.response.ApiCommonResponse;
+import org.bobj.point.RefundRequestDto;
 import org.bobj.point.domain.PointTransactionVO;
 import org.bobj.point.service.PointService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +42,26 @@ public class PointController {
         Long balance = pointService.getTotalPoint(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
     }
+
+
+
+    @PostMapping("/refund")
+    @ApiOperation(value = "포인트 환급 요청", notes = "사용자가 입력한 금액만큼 포인트를 환급 요청합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "환급 요청 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 400, message = "잘못된 요청 (잔액 부족 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<String>> requestRefund(
+        @RequestBody RefundRequestDto refundRequestDto,
+        Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        pointService.requestRefund(userId, refundRequestDto.getAmount());
+        return ResponseEntity.ok(ApiCommonResponse.createSuccess("환급 요청이 완료되었습니다."));
+    }
+
+
 
 
 }


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사용자가 입력한 금액만큼 포인트를 환급 요청할 수 있는 기능을 구현했습니다.  
포인트 차감과 함께 거래 내역 테이블에 출금 로그를 기록합니다.

## 🔧 작업 내용
- `/api/point/refund` POST API 추가
- `PointService.requestRefund()` 구현 (잔액 차감 + 트랜잭션 기록)
- `RefundRequestDto` 생성 및 `@NotNull` 유효성 검증 적용
- `build.gradle`에 validation 의존성 추가

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
- [x] 잔액 부족 시 예외 정상 처리 확인
- [x] 거래 내역 테이블에 출금 기록 저장 확인

## 📝 기타 참고 사항
- 현재는 `Principal` null 대응으로 userId를 임시 하드코딩한 상태
- 추후 로그인 인증 기능 연동 시 수정 필요

## 📎 관련 이슈
Close #102 
