### PR TITLE
[FEAT] #120 Add expectedDividendPerShare to funding detail API and add cumulative return to sold properties and funding list APIs and implement logic to update cumulative return upon sale completion

### DIFF
--- a/src/main/java/org/bobj/funding/dto/FundingDetailResponseDTO.java
+++ b/src/main/java/org/bobj/funding/dto/FundingDetailResponseDTO.java
@@ -76,6 +76,9 @@ public class FundingDetailResponseDTO {
     @ApiModelProperty(value = "상세 설명", example = "역세권이며 투자 가치가 높습니다.")
     private String description;
 
+    @ApiModelProperty(value="예상 주 당 배당금", example = "20")
+    private BigDecimal expectedDividendPerShare;
+
     @ApiModelProperty(value = "사진 목록")
     private List<PhotoDTO> photos;
 

--- a/src/main/java/org/bobj/funding/dto/FundingTotalResponseDTO.java
+++ b/src/main/java/org/bobj/funding/dto/FundingTotalResponseDTO.java
@@ -1,5 +1,6 @@
 package org.bobj.funding.dto;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,9 @@ public class FundingTotalResponseDTO {
 
     @ApiModelProperty("목표 금액")
     private BigDecimal targetAmount;
+
+    @ApiModelProperty("누적 수익률")
+    private BigDecimal cumulativeReturn;
 
     @ApiModelProperty("모집률 (%)")
     private Integer fundingRate;

--- a/src/main/java/org/bobj/property/dto/PropertySoldResponseDTO.java
+++ b/src/main/java/org/bobj/property/dto/PropertySoldResponseDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,4 +17,8 @@ public class PropertySoldResponseDTO {
     private Long propertyId;
     @ApiModelProperty(value = "썸네일 이미지 정보")
     private PhotoDTO thumbnail;
+    @ApiModelProperty("매물 제목")
+    private String title;
+    @ApiModelProperty("누적 수익률")
+    private BigDecimal cumulativeReturn;
 }

--- a/src/main/java/org/bobj/property/service/PropertyService.java
+++ b/src/main/java/org/bobj/property/service/PropertyService.java
@@ -199,7 +199,7 @@ public class PropertyService {
                 .map(FundingSoldResponseDTO::getPropertyId)
                 .collect(Collectors.toList());
 
-        // 1. 매물 상태를 SOLD, updated_at, sold_at 수정
+        // 1. 매물 상태를 SOLD, updated_at, sold_at 수정 + 누적 수익률 계산
         propertyMapper.updatePropertiesAsSold(propertyIds);
 
         // 멀티 스레드 설정

--- a/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
@@ -25,6 +25,7 @@
     <result property="officialLandPrice" column="official_land_price"/>
     <result property="unitPricePerPyeong" column="unit_price_per_pyeong"/>
     <result property="description" column="description"/>
+    <result property="expectedDividendPerShare" column="expected_dividend_per_share"/>
 
     <association property="seller" javaType="org.bobj.property.dto.SellerDTO">
       <result property="userId" column="user_id"/>
@@ -65,6 +66,7 @@
       p.official_land_price,
       p.unit_price_per_pyeong,
       p.description,
+      CEIL(p.rental_income/f.total_shares) AS expected_dividend_per_share,
       u.user_id,
       u.name,
 --       u.email,
@@ -123,6 +125,7 @@
     <result property="propertyId" column="property_id"/>
     <result property="title" column="title"/>
     <result property="address" column="address"/>
+    <result property="cumulativeReturn" column="cumulative_return"/>
     <result property="targetAmount" column="target_amount"/>
     <result property="fundingRate" column="fundingRate"/>
     <result property="daysLeft" column="daysLeft"/>
@@ -141,6 +144,7 @@
       f.property_id,
       p.title,
       p.address,
+      p.cumulative_return,
       f.target_amount,
       FLOOR((f.current_amount / f.target_amount) * 100) AS fundingRate,
       DATEDIFF(DATE(f.funding_end_date),DATE(NOW())) AS daysLeft,

--- a/src/main/resources/org/bobj/property/mapper/PropertyMapper.xml
+++ b/src/main/resources/org/bobj/property/mapper/PropertyMapper.xml
@@ -188,6 +188,8 @@
     <select id="findSold" resultMap="PropertySoldMap">
         SELECT
             p.property_id,
+            p.title,
+            p.cumulative_return,
             (SELECT photo_url
              FROM property_photos
              WHERE property_id = p.property_id
@@ -200,6 +202,8 @@
 
     <resultMap id="PropertySoldMap" type="org.bobj.property.dto.PropertySoldResponseDTO">
         <id property="propertyId" column="property_id"/>
+        <result property="title" column="title"/>
+        <result property="cumulativeReturn" column="cumulative_return"/>
         <association property="thumbnail" javaType="org.bobj.property.dto.PhotoDTO">
             <result property="photoUrl" column="thumbnail_url"/>
         </association>
@@ -237,7 +241,8 @@
         UPDATE properties
         SET status = 'SOLD',
         sold_at = NOW(),
-        updated_at = NOW()
+        updated_at = NOW(),
+        cumulative_return = ROUND(24 * rental_income / price * 100, 2)
         WHERE property_id IN
         <foreach collection="propertyIds" item="id" open="(" separator="," close=")">
             #{id}


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
펀딩 상세 조회 API에 예상 주당 배당금 속성 추가
매각 완료 매물 조회, 펀딩 리스트 조회 API에 누적 수익률 속성 추가
매각 완료 시 누적 수익률 업데이트 로직 구현

## 🔧 작업 내용

## ✅ 체크리스트
- [ ] 펀딩 상세 조회 API에 예상 주당 배당금 속성 추가
- [ ] 매각 완료 매물 조회, 펀딩 리스트 조회 API에 누적 수익률 속성 추가
- [ ] 매각 완료 시 누적 수익률 업데이트 로직 구현

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #120 
