### PR TITLE
[FEAT] #125 implement point refund logic for sold funding shares

### DIFF
--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -120,6 +120,30 @@ public class PointService {
         pointTransactionRepository.insert(tx);
     }
 
+    //userId에게 amount만큼 환급 포인트를 지급
+    @Transactional
+    public void refundForShareSell(Long userId, BigDecimal amount) {
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+        if (point == null) {
+            point = PointVO.builder().userId(userId).amount(amount).build();
+            pointRepository.insert(point);
+        } else {
+            point.setAmount(point.getAmount().add(amount));
+            pointRepository.update(point);
+        }
+
+        //트랜잭션 로그로 남기기 위해 PointTransactionVO 객체를 생성
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(PointTransactionType.REFUND)
+            .amount(amount)
+            .createdAt(LocalDateTime.now())
+            .build();
+        //위에서 만든 트랜잭션 기록을 POINT_TRANSACTION 테이블에 insert
+        pointTransactionRepository.insert(tx);
+    }
+
+
 
 
 }

--- a/src/main/java/org/bobj/property/service/PropertyService.java
+++ b/src/main/java/org/bobj/property/service/PropertyService.java
@@ -6,10 +6,13 @@ import org.bobj.common.dto.CustomSlice;
 import org.bobj.common.s3.S3Service;
 import org.bobj.funding.dto.FundingSoldResponseDTO;
 import org.bobj.funding.mapper.FundingMapper;
+import org.bobj.point.service.PointService;
 import org.bobj.property.domain.PropertyDocumentType;
 import org.bobj.property.domain.PropertyVO;
 import org.bobj.property.dto.*;
 import org.bobj.property.mapper.PropertyMapper;
+import org.bobj.share.domain.ShareVO;
+import org.bobj.share.mapper.ShareMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +35,8 @@ public class PropertyService {
     private final FundingMapper fundingMapper;
     private final RentalIncomeService rentalIncomeService;
     private final S3Service s3Service;
+    private final ShareMapper shareMapper;
+    private final PointService pointService;
 
     // 매물 승인 + 펀딩 등록 or 거절
     @Transactional
@@ -210,7 +215,11 @@ public class PropertyService {
             Long fundingId = dto.getFundingId();
             executor.submit(()->{
                 /* fundingId에 해당하는 share 가져오기(share 테이블)*/
+                List<ShareVO> shares = shareMapper.findByFundingId(fundingId);
                 /* 해당하는 지분에 point 환불(point 테이블) */
+                for (ShareVO share : shares) {
+//                    pointService.refundForShareSell(share.getUserId(),  (매각 차익 / 5000)* share.getShareCount());
+                }
             });
         }
         executor.shutdown();

--- a/src/main/java/org/bobj/property/service/PropertyService.java
+++ b/src/main/java/org/bobj/property/service/PropertyService.java
@@ -218,7 +218,8 @@ public class PropertyService {
                 List<ShareVO> shares = shareMapper.findByFundingId(fundingId);
                 /* 해당하는 지분에 point 환불(point 테이블) */
                 for (ShareVO share : shares) {
-//                    pointService.refundForShareSell(share.getUserId(),  (매각 차익 / 5000)* share.getShareCount());
+                    pointService.refundForShareSell(share.getUserId(),
+                        BigDecimal.valueOf(5000* share.getShareCount()));
                 }
             });
         }

--- a/src/main/java/org/bobj/share/mapper/ShareMapper.java
+++ b/src/main/java/org/bobj/share/mapper/ShareMapper.java
@@ -32,4 +32,7 @@ public interface ShareMapper {
 
     //주식 데이터 배치 삽입
     int insertSharesBatch(List<ShareVO> shares);
+
+    List<ShareVO> findByFundingId(Long fundingId);
+
 }

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -137,4 +137,11 @@
         <result property="thumbnailUrl" column="thumbnail_url"/>
     </resultMap>
 
+    <!-- 특정 펀딩 ID에 대한 모든 지분 조회 -->
+    <select id="findByFundingId" resultType="org.bobj.share.domain.ShareVO">
+        SELECT *
+        FROM SHARES
+        WHERE funding_id = #{fundingId}
+    </select>
+
 </mapper>


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

매각 완료된 펀딩의 지분 보유자들에게 포인트 환급 기능을 구현했습니다.  
총 수익을 총 발행 지분 수로 나누고, 사용자 보유 지분 수에 비례하여 환급 포인트를 계산할 예정입니다.
그러나 현재는 5000(주식 현재가) * 주식 보유량으로 수익을 지급합니다.

## 🔧 작업 내용

- ShareMapper에 `findByFundingId(fundingId)` 쿼리 추가
- 사용자 보유 지분 수에 따라 포인트 환급 처리
- `PointService.refundForShareSell()` 메서드 추가

## ✅ 체크리스트

## 📝 기타 참고 사항

- 추후 로그나 알림 처리, 수익률 변동 정책이 있을 경우 확장 가능합니다.

## 📎 관련 이슈
Close #125
