### PR TITLE
[FEAT] #126 implement point deduction logic when creating funding orders

### DIFF
--- a/src/main/java/org/bobj/funding/service/FundingOrderService.java
+++ b/src/main/java/org/bobj/funding/service/FundingOrderService.java
@@ -9,6 +9,7 @@ import org.bobj.funding.dto.FundingOrderUserResponseDTO;
 import org.bobj.funding.event.ShareDistributionEvent;
 import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.funding.mapper.FundingOrderMapper;
+import org.bobj.point.service.PointService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class FundingOrderService {
 
     private final ShareDistributionService shareDistributionService;
     private final ApplicationEventPublisher eventPublisher;
+    private final PointService pointService;
 
     // 주문 추가
     @Transactional
@@ -44,8 +46,11 @@ public class FundingOrderService {
         BigDecimal orderPrice = sharePrice.multiply(BigDecimal.valueOf(shareCount));
 
         /* 요기 구현해주시면 됩니다! (Point) */
+
         // user의 point 가져오는 api 부탁드려요!! PointMapper.findUserPoints(userId)
-        BigDecimal userPoints = BigDecimal.valueOf(100000);
+        BigDecimal userPoints = pointService.getTotalPoint(userId);
+
+//        BigDecimal userPoints = BigDecimal.valueOf(100000);
         if (userPoints.compareTo(orderPrice) < 0) {
             throw new IllegalArgumentException("포인트가 부족합니다.");
         }
@@ -55,6 +60,7 @@ public class FundingOrderService {
 
         /* 요기 구현해주시면 됩니다! (Point) */
         // 포인트 차감 과정(추후 구현)
+        pointService.investPoint(userId, orderPrice);
 
         // 펀딩 현재 모인 금액 증가
         fundingMapper.increaseCurrentAmount(fundingId, orderPrice);

--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -3,6 +3,7 @@ package org.bobj.point.controller;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.math.BigDecimal;
 import java.security.Principal;
 import java.util.List;
 import java.util.function.LongPredicate;
@@ -37,9 +38,9 @@ public class PointController {
 
     @GetMapping("/balance")
     @ApiOperation(value = "현재 포인트 보유량 조회", notes = "로그인한 사용자의 현재 포인트 보유량을 반환합니다.")
-    public ResponseEntity<ApiCommonResponse<Long>> getPointBalance(Principal principal) {
+    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalance(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
-        Long balance = pointService.getTotalPoint(userId);
+        BigDecimal balance = pointService.getTotalPoint(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
     }
 

--- a/src/main/java/org/bobj/point/mapper/PointMapper.java
+++ b/src/main/java/org/bobj/point/mapper/PointMapper.java
@@ -1,5 +1,6 @@
 package org.bobj.point.mapper;
 
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -21,7 +22,8 @@ public interface PointMapper {
     PointVO findByUserIdForUpdate(@Param("userId") Long userId);
 
 
-    Long findTotalPointByUserId(Long userId);
+    BigDecimal findTotalPointByUserId(Long userId);
+
 
 
 }

--- a/src/main/java/org/bobj/point/repository/PointRepository.java
+++ b/src/main/java/org/bobj/point/repository/PointRepository.java
@@ -1,6 +1,7 @@
 package org.bobj.point.repository;
 
 
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bobj.point.domain.PointVO;
@@ -37,7 +38,7 @@ public class PointRepository {
         return pointMapper.findByUserIdForUpdate(userId);
     }
 
-    public Long findTotalPointByUserId(Long userId) {
+    public BigDecimal findTotalPointByUserId(Long userId) {
         return pointMapper.findTotalPointByUserId(userId);
     }
 

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -87,7 +87,7 @@ public class PointService {
         pointTransactionRepository.insert(tx);
     }
 
-    public Long getTotalPoint(Long userId) {
+    public BigDecimal getTotalPoint(Long userId) {
         // 포인트 테이블에서 현재 보유 포인트 계산
         return pointRepository.findTotalPointByUserId(userId);
     }
@@ -144,6 +144,28 @@ public class PointService {
     }
 
 
+
+    @Transactional
+    public void investPoint(Long userId, BigDecimal amount) {
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+        if (point == null || point.getAmount().compareTo(amount) < 0) {
+            throw new IllegalArgumentException("포인트가 부족합니다.");
+        }
+
+        // 포인트 차감
+        point.setAmount(point.getAmount().subtract(amount));
+        pointRepository.update(point);
+
+        // 트랜잭션 기록
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(PointTransactionType.INVEST) // enum에 정의돼 있어야 함
+            .amount(amount)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        pointTransactionRepository.insert(tx);
+    }
 
 
 }

--- a/src/main/resources/org/bobj/point/mapper/PointMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointMapper.xml
@@ -37,7 +37,7 @@
     DELETE FROM point WHERE point_id = #{pointId}
   </delete>
 
-  <select id="findTotalPointByUserId" resultType="long" parameterType="long">
+  <select id="findTotalPointByUserId" resultType="java.math.BigDecimal" parameterType="long">
     SELECT COALESCE(SUM(
                       CASE
                         WHEN type IN ('DEPOSIT', 'TRADE_SALE', 'PAYOUT', 'REFUND', 'CANCEL') AND status = 'COMPLETED' THEN amount
@@ -48,6 +48,7 @@
     FROM point_transactions
     WHERE user_id = #{userId}
   </select>
+
 
 
 


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

펀딩 주문 생성 시 사용자의 포인트 잔액을 확인하고, 주문 금액만큼 포인트를 차감하는 기능을 구현했습니다.

## 🔧 작업 내용

- `FundingOrderService.createFundingOrder()` 내 포인트 차감 로직 구현
- `PointService.getTotalPoint()` 활용하여 사용자 보유 포인트 확인
- 부족할 경우 예외 발생 (`IllegalArgumentException`)
- 주문 성공 시 `PointService.investPoint()` 호출하여 포인트 차감 및 트랜잭션 기록

## ✅ 체크리스트


## 📝 기타 참고 사항

- 포인트 차감 로직은 트랜잭션 안에서 처리되며, 데이터 정합성을 보장합니다.
- 추후 주문 취소 기능에 포인트 환불 로직을 연동할 수 있습니다.

## 📎 관련 이슈
Close #126
