### PR TITLE
[FEAT] #128 implement point refund for failed funding

### DIFF
--- a/src/main/java/org/bobj/funding/service/FundingService.java
+++ b/src/main/java/org/bobj/funding/service/FundingService.java
@@ -3,11 +3,13 @@ package org.bobj.funding.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bobj.common.dto.CustomSlice;
+import org.bobj.funding.domain.FundingOrderVO;
 import org.bobj.funding.dto.FundingDetailResponseDTO;
 import org.bobj.funding.dto.FundingEndedResponseDTO;
 import org.bobj.funding.dto.FundingTotalResponseDTO;
 import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.funding.mapper.FundingOrderMapper;
+import org.bobj.point.service.PointService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ import java.util.concurrent.Future;
 public class FundingService {
     private final FundingMapper fundingMapper;
     private final FundingOrderMapper fundingOrderMapper;
+    private final PointService pointService;
 
     private static final int BATCH_SIZE = 1000;
 
@@ -61,6 +64,14 @@ public class FundingService {
                     fundingOrderMapper.updateFundingOrderStatusToRefundedByOrderIds(fundingOrderIdBatch);
 
                     /* 여기에 포인트 환불 로직 추가 해주세요!(point테이블)*/
+                    List<FundingOrderVO> allOrders = fundingOrderMapper.findAllOrdersByFundingId(fId);
+
+                    for (FundingOrderVO order : allOrders) {
+                        if (fundingOrderIdBatch.contains(order.getOrderId())) {
+                            pointService.refundForFundingFailure(order.getUserId(), order.getOrderPrice());
+                        }
+                    }
+
                     return null;
                 });
             }

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -167,5 +167,34 @@ public class PointService {
         pointTransactionRepository.insert(tx);
     }
 
+    /**
+     * 펀딩 실패 시 포인트 환급
+     */
+    @Transactional
+    public void refundForFundingFailure(Long userId, BigDecimal amount) {
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+
+        if (point == null) {
+            point = PointVO.builder()
+                .userId(userId)
+                .amount(amount)
+                .build();
+            pointRepository.insert(point);
+        } else {
+            point.setAmount(point.getAmount().add(amount));
+            pointRepository.update(point);
+        }
+
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(PointTransactionType.REFUND)
+            .amount(amount)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        pointTransactionRepository.insert(tx);
+    }
+
+
 
 }


### PR DESCRIPTION

## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

펀딩 실패 시, 해당 주문들을 환불 처리하고 사용자에게 포인트를 반환하는 기능을 추가했습니다.

## 🔧 작업 내용

- `FundingService.expireFunding()`에 포인트 환불 로직 추가
- 주문 정보 기준으로 사용자에게 포인트 환급 수행
- `PointService.refundForFundingFailure(userId, amount)` 메서드 구현

## ✅ 체크리스트

## 📝 기타 참고 사항

- 환불 처리는 멀티 스레드로 병렬 처리되며, 트랜잭션 안정성을 위해 `@Transactional`과 `FOR UPDATE`를 사용합니다.

## 📎 관련 이슈
Close #128
