### PR TITLE
[FEAT] refund user points on funding order cancellation

### DIFF
--- a/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
+++ b/src/main/java/org/bobj/funding/mapper/FundingOrderMapper.java
@@ -45,4 +45,7 @@ public interface FundingOrderMapper {
     // 펀딩 주문 ID 리스트에 해당하는 펀딩 주문 데이터 status 수정
     void updateFundingOrderStatusToRefundedByOrderIds(@Param("orderIds") List<Long> orderIds);
 
+    FundingOrderVO findById(@Param("orderId") Long orderId);
+
+
 }

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -195,6 +195,34 @@ public class PointService {
         pointTransactionRepository.insert(tx);
     }
 
+    /**
+     * 사용자가 펀딩 주문을 직접 취소했을 때 포인트 환급
+     */
+    @Transactional
+    public void refundForFundingCancel(Long userId, BigDecimal amount) {
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+
+        if (point == null) {
+            point = PointVO.builder()
+                .userId(userId)
+                .amount(amount)
+                .build();
+            pointRepository.insert(point);
+        } else {
+            point.setAmount(point.getAmount().add(amount));
+            pointRepository.update(point);
+        }
+
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(PointTransactionType.REFUND)
+            .amount(amount)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        pointTransactionRepository.insert(tx);
+    }
+
 
 
 }

--- a/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
@@ -129,4 +129,11 @@
             #{id}
         </foreach>
     </update>
+
+  <select id="findById" resultType="org.bobj.funding.domain.FundingOrderVO">
+    SELECT order_id, user_id, order_price
+    FROM funding_orders
+    WHERE order_id = #{orderId}
+  </select>
+
 </mapper>


### PR DESCRIPTION


## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

사용자가 펀딩 주문을 취소할 경우, 해당 주문 금액만큼 포인트를 환불하고 트랜잭션 로그를 기록합니다.

## 🔧 작업 내용

- `PointService.refundForFundingCancel()` 메서드 추가
- `FundingOrderService.refundFundingOrder()` 내부에 포인트 환급 처리 추가
- `FundingOrderMapper.findById(orderId)` 메서드 정의 및 사용
- 환불된 포인트는 `PointTransactionType.REFUND`로 기록

## ✅ 체크리스트


## 📝 기타 참고 사항

- 추후 포인트 트랜잭션 타입을 `FUNDING_CANCEL_REFUND` 등으로 세분화할 수 있습니다.
- 주문 취소 이후 현재 펀딩 모금액에서 금액 차감도 함께 반영됩니다.

## 📎 관련 이슈
Close #139 
