### PR TITLE
[FIX] #141 Standardize SQL statements by uppercasing keywords

### DIFF
--- a/src/main/resources/org/bobj/order/mapper/OrderMapper.xml
+++ b/src/main/resources/org/bobj/order/mapper/OrderMapper.xml
@@ -73,7 +73,7 @@
 
     <!-- 주문이 체결되거나 부분 체결될 때, 해당 주문의 남은 수량과 상태를 업데이트   -->
     <update id="updateOrderBookStatusAndRemainingCount">
-        UPDATE ORDER_BOOKS
+        UPDATE order_books
         SET
             status = #{status}, -- 'FULLY_FILLED', 'PARTIALLY_FILLED'
             remaining_share_count = #{remainingShareCount},
@@ -86,7 +86,7 @@
     <select id="findMatchingOrders" resultType="org.bobj.order.domain.OrderVO">
         SELECT *
         FROM
-        ORDER_BOOKS
+        order_books
         WHERE
         funding_id = #{fundingId}
         AND order_type = #{oppositeOrderType} -- 반대편 주문 타입 조회
@@ -113,7 +113,7 @@
             remaining_share_count,   -- 잔여 수량
             order_type               -- 주문 타입 (BUY/SELL)
         FROM
-            ORDER_BOOKS
+            order_books
         WHERE
             funding_id = #{fundingId}
             AND status IN ('PENDING', 'PARTIALLY_FILLED')


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
SQL 키워드의 표기 일관성을 위해, 모든 SQL 문에서 키워드를 소문자로 통일했습니다.

## 🔧 작업 내용
- `SELECT`, `FROM`, `WHERE`, `JOIN` 등 대문자로 작성된 SQL 키워드를 모두 소문자로 변경 (`select`, `from`, `where`, `join` 등)
- 일부 파일에서 혼용되어 있던 키워드 표기를 통일
- SQL 가독성과 협업 시 코드 스타일 일관성을 위한 수정

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
- [x] 기존 쿼리 정상 작동 확인
- [x] 문법 오류 없음

## 📝 기타 참고 사항
- 팀 내 SQL 스타일 가이드에 따라 키워드는 모두 소문자로 작성하도록 통일한 작업입니다.


## 📎 관련 이슈
Close #141
