### PR TITLE
[FIX] #142 Lowercase SQL keywords in trade/share mapper and update verify API

### DIFF
--- a/src/main/java/org/bobj/payment/dto/VerifyRequestDto.java
+++ b/src/main/java/org/bobj/payment/dto/VerifyRequestDto.java
@@ -21,6 +21,9 @@ public class VerifyRequestDto {
     @ApiModelProperty(value = "포트원 imp_uid", example = "imp_123456789012", required = true)
     private String impUid;
 
+    @ApiModelProperty(value = "가맹점 고유 주문번호 (merchant_uid)", example = "point_20250804001510_1_fba1d505", required = true)
+    private String merchantUid;
+
     @ApiModelProperty(value = "결제 금액", example = "5000", required = true)
     private BigDecimal amount;
 

--- a/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
+++ b/src/main/resources/org/bobj/share/mapper/ShareMapper.xml
@@ -6,7 +6,7 @@
 
     <!-- 펀딩 보유 주 삽입-->
     <insert id="insert" parameterType="org.bobj.share.domain.ShareVO">
-        INSERT INTO SHARES (
+        INSERT INTO shares (
             user_id,
             funding_id,
             share_count,
@@ -24,7 +24,7 @@
 
     <!-- 펀딩 보유 주 수 업데이트-->
     <update id="update">
-        UPDATE SHARES
+        UPDATE shares
         SET
             share_count = #{shareCount},
             average_amount = #{averageAmount},
@@ -36,20 +36,20 @@
     <!-- 사용자 펀딩 보유 주 수 가져오기-->
     <select id="findUserShareCount" resultType="java.lang.Integer">
         SELECT SUM(share_count)
-        FROM SHARES
+        FROM shares
         WHERE user_id = #{userId}
           AND funding_id = #{fundingId} FOR UPDATE
     </select>
 
     <select id="findUserShareByFundingIdForUpdate" resultType="org.bobj.share.domain.ShareVO">
         SELECT *
-        FROM SHARES
+        FROM shares
         WHERE user_id = #{userId}
           AND funding_id = #{fundingId} FOR UPDATE
     </select>
 
     <delete id="delete">
-        DELETE FROM SHARES
+        DELETE FROM shares
         WHERE share_id = #{shareId}
     </delete>
 
@@ -140,7 +140,7 @@
     <!-- 특정 펀딩 ID에 대한 모든 지분 조회 -->
     <select id="findByFundingId" resultType="org.bobj.share.domain.ShareVO">
         SELECT *
-        FROM SHARES
+        FROM shares
         WHERE funding_id = #{fundingId}
     </select>
 

--- a/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
+++ b/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
@@ -6,7 +6,7 @@
 
     <!--채결 내역 삽입-->
     <insert id="insert" parameterType="org.bobj.trade.domain.TradeVO">
-        INSERT INTO TRADES (
+        INSERT INTO trades (
         buy_order_id,
         sell_order_id,
         buyer_user_id,
@@ -38,7 +38,7 @@
             t.trade_price_per_share,
             t.created_at
         FROM
-            TRADES t
+            trades t
         JOIN
             ORDER_BOOKS ob_buy ON t.buy_order_id = ob_buy.order_id
         WHERE
@@ -50,7 +50,7 @@
 
     <select id="findLatestTradePriceByFundingId" resultType="java.math.BigDecimal">
         SELECT t.trade_price_per_share
-        FROM TRADES t
+        FROM trades t
          JOIN
              ORDER_BOOKS ob_buy ON t.buy_order_id = ob_buy.order_id
         WHERE
@@ -71,7 +71,7 @@
              t.trade_price_per_share,
              t.trade_count AS total_volume,
              ROW_NUMBER() OVER (PARTITION BY DATE(t.created_at) ORDER BY t.created_at DESC) AS rn
-        FROM TRADES t
+        FROM trades t
             JOIN ORDER_BOOKS ob ON t.buy_order_id = ob.order_id OR t.sell_order_id = ob.order_id
         WHERE ob.funding_id = #{fundingId}
           AND t.created_at BETWEEN #{startDate} AND DATE_ADD(#{endDate}, INTERVAL 1 DAY)


### PR DESCRIPTION
[FIX] #142 Lowercase SQL keywords in trade/share mapper and update verify API

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
SQL 문법 일관성을 위해 Mapper 파일 내 SQL 키워드를 소문자로 변경하고, 누락된 verify API의 `merchant_id` 파라미터를 추가하였습니다.

## 🔧 작업 내용
- trademapper.xml의 SQL 키워드를 소문자로 수정
- sharemapper.xml의 SQL 키워드를 소문자로 수정
- verify API 요청에 `merchant_id` 파라미터 추가

## ✅ 체크리스트
- [x] 테스트 완료 (Postman, Swagger 등으로 verify API 정상 동작 확인)
- [x] 변경된 Mapper SQL 정상 동작 확인

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #142
