### PR TITLE
[FIX] #156 change and setting dockerfile TZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM tomcat:9.0-jdk17-temurin
 
+# ✅ tzdata 설치 및 타임존 설정 추가
+RUN apt-get update && \
+    apt-get install -y tzdata && \
+    ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata
+
 # 기존 webapps 폴더 비우기
 RUN rm -rf /usr/local/tomcat/webapps/*
 


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

도커 컨테이너의 기본 타임존이 UTC로 설정되어 있어,  
로그, DB, 파일 생성 시간 등이 한국 시간과 맞지 않는 문제가 발생했습니다.  
Dockerfile을 수정하여 타임존을 `Asia/Seoul`로 변경했습니다.

## 🔧 작업 내용

- Dockerfile에 `tzdata` 설치 명령 추가
- `/etc/localtime`을 `Asia/Seoul`로 설정
- `/etc/timezone` 파일 업데이트
- `dpkg-reconfigure` 명령어로 타임존 반영
- 변경 사항 반영 후 Docker 재빌드 및 배포

## ✅ 체크리스트
- [x] 컨테이너 내에서 `date` 명령어로 KST 출력 확인
- [ ] GitHub Actions 배포 이후 시간 확인 완료

## 📝 기타 참고 사항

- `docker-compose up --build` 명령으로 반영 필요
- CI/CD 자동화 시 시간 동작 여부도 함께 점검 필요

## 📎 관련 이슈
Close #156 
