### PR TITLE
[CHORE] #175 change ci-cd.yml 71 line

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,6 +68,6 @@ jobs:
           cd /home/ubuntu/app
           docker compose down || true
           docker compose pull
-          docker compose up -d
+          docker compose up -d --build
           docker compose ps
           EOF


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [x] 기타

## 📌 개요
CI/CD 배포 단계에서 잘못된 Docker Compose 명령어 수정

## 🔧 작업 내용
- 기존: `docker compose up -d build`
- 변경: `docker compose up -d --build`
- 올바른 명령어로 수정하여 빌드 실패 방지

## ✅ 체크리스트
- [x] 테스트 완료(GitHub Actions 정상 작동 확인)
- [ ] 로컬 테스트 (해당 없음)
- [ ] Swagger 테스트 (해당 없음)

## 📝 기타 참고 사항
- `docker compose up -d build`는 `build`라는 서비스를 찾으려 하므로 에러 발생
- `--build` 플래그를 추가해야 Dockerfile 변경 반영됨

## 📎 관련 이슈
Close #175
