### PR TITLE
[CHORE] #178 Add debug step for application.properties injection from…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,8 +28,16 @@ jobs:
           ${{ secrets.APP_PROPERTIES }}
           EOF
 
+      - name:
+          🔍 Debug: print application.properties
+        run: |
+          echo "===== application.properties (START) ====="
+          cat src/main/resources/application.properties
+          echo "===== application.properties (END) ====="
+
       - name: Build WAR file (Skip tests)
         run: ./gradlew clean build -x test
+
 
       - name: Check WAR output
         run: ls -al build/libs


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

application.properties가 WAR 파일에 포함되었음에도 불구하고 비어있는 문제가 발생했습니다.  
이 PR에서는 GitHub Secrets에서 주입된 값이 제대로 들어가는지 확인하기 위한 디버깅 코드를 추가합니다.

## 🔧 작업 내용

- GitHub Actions 워크플로우에 `cat src/main/resources/application.properties` 명령 추가
- Secrets 값 주입 확인용 디버깅 로그 출력
- 비어 있는 설정파일 문제의 원인 추적

## ✅ 체크리스트
- [x] GitHub Actions 디버깅 스텝 동작 확인
- [x] Secrets 값이 로그에 출력되는지 확인
- [ ] 필요 시 base64 방식 도입 고려

## 📝 기타 참고 사항

- 추후 줄바꿈 이슈 방지를 위해 Secrets 주입 방식을 base64로 전환할 수 있음

## 📎 관련 이슈
Close #178
