### PR TITLE
[CHORE] #178 Add debug step for application.properties injection from GitHub Secrets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,8 +28,7 @@ jobs:
           ${{ secrets.APP_PROPERTIES }}
           EOF
 
-      - name:
-          🔍 Debug: print application.properties
+      - name: 🔍 Debug print application.properties
         run: |
           echo "===== application.properties (START) ====="
           cat src/main/resources/application.properties
@@ -37,7 +36,6 @@ jobs:
 
       - name: Build WAR file (Skip tests)
         run: ./gradlew clean build -x test
-
 
       - name: Check WAR output
         run: ls -al build/libs


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

GitHub Actions CI/CD 파이프라인에서 `application.properties`가 정상적으로 주입되지 않는 문제를 디버깅하기 위한 수정입니다.

Secrets에서 값이 잘 들어오고 줄바꿈이 적용되는지 확인하기 위해 디버깅 스텝(`cat`)을 추가하고, YAML 문법 오류도 함께 수정했습니다.

## 🔧 작업 내용

- `application.properties` 주입 시 `<<EOF` YAML 오류 해결 (들여쓰기 제거)
- CI 로그에 `application.properties` 내용을 출력하는 디버깅 스텝 추가
- 줄바꿈 누락으로 인해 WAR에 빈 설정 파일이 포함되던 문제 해결

## ✅ 체크리스트
- [x] GitHub Actions 정상 실행 확인
- [x] application.properties가 정상적으로 포함되는지 확인
- [x] 디버깅 로그에 설정값 출력 확인

## 📝 기타 참고 사항

- 필요 시 base64 인코딩 방식으로 secrets 주입 방식을 개선할 수 있습니다.
- 해당 디버깅 코드는 문제 해결 후 제거 예정입니다.

## 📎 관련 이슈
Close #181
