### PR TITLE
[FIX] 채결 내역 조회 endDate 범위 오류 수정

### DIFF
--- a/src/main/java/org/bobj/funding/controller/FundingHistoryController.java
+++ b/src/main/java/org/bobj/funding/controller/FundingHistoryController.java
@@ -22,9 +22,9 @@ public class FundingHistoryController {
     @GetMapping("/{fundingId}/trades")
     @ApiOperation(value = "펀딩 일별 거래 내역 조회", notes = "특정 펀딩의 일별 종가, 거래량 및 변화율을 조회합니다. (daily 고정)")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "fundingId", value = "조회할 펀딩 ID", required = true, dataType = "long", paramType = "path"),
+            @ApiImplicitParam(name = "fundingId", value = "조회할 펀딩 ID", required = true, dataType = "long", paramType = "path", example = "1"),
             @ApiImplicitParam(name = "startDate", value = "조회 시작일 (YYYY-MM-DD)", required = false, dataType = "string", paramType = "query", example = "2025-06-01"),
-            @ApiImplicitParam(name = "endDate", value = "조회 종료일 (YYYY-MM-DD)", required = false, dataType = "string", paramType = "query", example = "2025-06-31"),
+            @ApiImplicitParam(name = "endDate", value = "조회 종료일 (YYYY-MM-DD)", required = false, dataType = "string", paramType = "query", example = "2025-06-30"),
             @ApiImplicitParam(name = "limit", value = "반환할 데이터 포인트 최대 개수", required = false, dataType = "int", paramType = "query", example = "100"),
             @ApiImplicitParam(name = "offset", value = "페이지네이션 오프셋", required = false, dataType = "int", paramType = "query", example = "0")
     })

--- a/src/main/java/org/bobj/trade/service/TradeHistoryServiceImpl.java
+++ b/src/main/java/org/bobj/trade/service/TradeHistoryServiceImpl.java
@@ -40,6 +40,15 @@ public class TradeHistoryServiceImpl implements TradeHistoryService{
             throw new IllegalArgumentException("funding id에 대한 펀딩이 존재하지 않습니다.");
         }
 
+        LocalDate today = LocalDate.now();
+        LocalDate maxAllowedDate = today.minusDays(1);
+        LocalDate requestedEndDate = requestDTO.getEndDate();
+
+        if (requestedEndDate.isAfter(maxAllowedDate)) {
+            throw new IllegalArgumentException("체결 내역은 현재 날짜 전날까지만 조회할 수 있습니다. (요청 endDate: "
+                    + requestedEndDate + ", 최대 허용: " + maxAllowedDate + ")");
+        }
+
         // 일별 체결 요약 데이터 조회
         List<DailyTradeHistoryDTO> dailySummaries = tradeMapper.findDailyTradeSummary(fundingId, requestDTO.getStartDate(), requestDTO.getEndDate());
 

--- a/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
+++ b/src/main/resources/org/bobj/trade/mapper/TradeMapper.xml
@@ -74,7 +74,7 @@
         FROM trades t
             JOIN order_books ob ON t.buy_order_id = ob.order_id OR t.sell_order_id = ob.order_id
         WHERE ob.funding_id = #{fundingId}
-          AND t.created_at BETWEEN #{startDate} AND DATE_ADD(#{endDate}, INTERVAL 1 DAY)
+          AND t.created_at BETWEEN #{startDate} AND #{endDate}
             ) AS daily_trades_with_rn
         GROUP BY trade_date
         ORDER BY trade_date ASC


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요

체결 내역 조회시
endDate 설정 날짜보다 하루 뒤 날짜까지 나오는 오류가 있었습니다.
endDate 설정 날짜까지만 보이도록 수정하였습니다.

## 🔧 작업 내용

체결 내역은 현재 날짜 하루 전날까지만 집계되어 보일 수 있도록
현재 날짜를 endDate로 설정할시 예외처리를 두었습니다.

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close ##226
