### PR TITLE
[FEAT] #231 Add orderId, orderPrice response to get user order API

### DIFF
--- a/src/main/java/org/bobj/funding/dto/FundingOrderUserResponseDTO.java
+++ b/src/main/java/org/bobj/funding/dto/FundingOrderUserResponseDTO.java
@@ -31,6 +31,11 @@ public class FundingOrderUserResponseDTO {
     @ApiModelProperty(value = "모집된 가격")
     private BigDecimal currentAmount;
 
+    @ApiModelProperty(value = "펀딩 주문 ID")
+    private Long orderId;
+    @ApiModelProperty(value = "주문 금액")
+    private BigDecimal orderPrice;
+
     // 펀딩 관련 필드 (APPROVED, SOLD 시만 유효)
     @ApiModelProperty(value = "달성률")
     private Integer achievementRate;

--- a/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingOrderMapper.xml
@@ -15,6 +15,8 @@
         FLOOR((f.current_amount / f.target_amount) * 100) AS achievement_rate,
         (f.target_amount - f.current_amount) / 5000 AS remaining_shares,
         (f.target_amount - f.current_amount) AS remaining_amount,
+        fo.order_id,
+        fo.order_price,
         fo.share_count,
         (SELECT photo_url
         FROM property_photos
@@ -40,6 +42,7 @@
   <resultMap id="FundingOrderUserMap" type="org.bobj.funding.dto.FundingOrderUserResponseDTO">
     <id property="propertyId" column="property_id"/>
     <id property="fundingId" column="funding_id"/>
+    <id property="orderId" column="order_id"/>
     <result property="title" column="title"/>
     <result property="shareCount" column="share_count"/>
     <result property="targetAmount" column="target_amount"/>
@@ -47,6 +50,7 @@
     <result property="achievementRate" column="achievement_rate"/>
     <result property="remainingShares" column="remaining_shares"/>
     <result property="remainingAmount" column="remaining_amount"/>
+    <result property="orderPrice" column="order_price"/>
     <association property="thumbnail" javaType="org.bobj.property.dto.PhotoDTO">
       <result property="photoUrl" column="thumbnail_url"/>
     </association>


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사용자의 투자 목록 조회 API의 response에 orderId, orderPrice 속성 추가

## 🔧 작업 내용

## ✅ 체크리스트
- [ ] 사용자의 투자 목록 조회 API의 response에 orderId, orderPrice 속성 추가

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #231
