### PR TITLE
[CHORE] #235 git change PointController

### DIFF
--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -22,47 +22,85 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+
+//Principal 적용 코드
+//@RestController
+//@RequestMapping("/api/point")
+//@RequiredArgsConstructor
+//public class PointController {
+//    private final PointService pointService;
+//    @GetMapping("/transactions")
+//    @ApiOperation(value = "포인트 입출금 내역 조회", notes = "로그인한 사용자의 포인트 입출금 트랜잭션 내역을 조회합니다.")
+//    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactions(Principal principal){
+//        Long userId = Long.parseLong(principal.getName());
+//        List<PointTransactionVO> transactions = pointService.findTransactionsByUserId(userId);
+//        return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
+//    }
+//
+//
+//    @GetMapping("/balance")
+//    @ApiOperation(value = "현재 포인트 보유량 조회", notes = "로그인한 사용자의 현재 포인트 보유량을 반환합니다.")
+//    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalance(Principal principal) {
+//        Long userId = Long.parseLong(principal.getName());
+//        BigDecimal balance = pointService.getTotalPoint(userId);
+//        return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
+//    }
+//
+//
+//
+//    @PostMapping("/refund")
+//    @ApiOperation(value = "포인트 환급 요청", notes = "사용자가 입력한 금액만큼 포인트를 환급 요청합니다.")
+//    @ApiResponses(value = {
+//        @ApiResponse(code = 200, message = "환급 요청 성공", response = ApiCommonResponse.class),
+//        @ApiResponse(code = 400, message = "잘못된 요청 (잔액 부족 등)", response = ErrorResponse.class),
+//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+//    })
+//    public ResponseEntity<ApiCommonResponse<String>> requestRefund(
+//        @RequestBody RefundRequestDto refundRequestDto,
+//        Principal principal
+//    ) {
+//        Long userId = Long.parseLong(principal.getName());
+//        pointService.requestRefund(userId, refundRequestDto.getAmount());
+//        return ResponseEntity.ok(ApiCommonResponse.createSuccess("환급 요청이 완료되었습니다."));
+//    }
+//}
 @RestController
 @RequestMapping("/api/point")
 @RequiredArgsConstructor
 public class PointController {
+
     private final PointService pointService;
+
     @GetMapping("/transactions")
-    @ApiOperation(value = "포인트 입출금 내역 조회", notes = "로그인한 사용자의 포인트 입출금 트랜잭션 내역을 조회합니다.")
-    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactions(Principal principal){
-        Long userId = Long.parseLong(principal.getName());
+    @ApiOperation(value = "포인트 입출금 내역 조회 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
+    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactionsForTest(
+        @RequestParam Long userId
+    ) {
         List<PointTransactionVO> transactions = pointService.findTransactionsByUserId(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
     }
 
-
     @GetMapping("/balance")
-    @ApiOperation(value = "현재 포인트 보유량 조회", notes = "로그인한 사용자의 현재 포인트 보유량을 반환합니다.")
-    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalance(Principal principal) {
-        Long userId = Long.parseLong(principal.getName());
+    @ApiOperation(value = "현재 포인트 보유량 조회 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
+    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalanceForTest(
+        @RequestParam Long userId
+    ) {
         BigDecimal balance = pointService.getTotalPoint(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
     }
 
-
-
     @PostMapping("/refund")
-    @ApiOperation(value = "포인트 환급 요청", notes = "사용자가 입력한 금액만큼 포인트를 환급 요청합니다.")
+    @ApiOperation(value = "포인트 환급 요청 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "환급 요청 성공", response = ApiCommonResponse.class),
         @ApiResponse(code = 400, message = "잘못된 요청 (잔액 부족 등)", response = ErrorResponse.class),
         @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
-    public ResponseEntity<ApiCommonResponse<String>> requestRefund(
-        @RequestBody RefundRequestDto refundRequestDto,
-        Principal principal
+    public ResponseEntity<ApiCommonResponse<String>> requestRefundForTest(
+        @RequestParam Long userId,
+        @RequestBody RefundRequestDto refundRequestDto
     ) {
-        Long userId = Long.parseLong(principal.getName());
         pointService.requestRefund(userId, refundRequestDto.getAmount());
         return ResponseEntity.ok(ApiCommonResponse.createSuccess("환급 요청이 완료되었습니다."));
     }
-
-
-
-
 }


### PR DESCRIPTION

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Swagger 환경에서 인증 없이 userId를 직접 입력해 포인트 관련 API를 테스트할 수 있도록 `Principal` 의존성을 제거하고 `@RequestParam Long userId` 방식으로 변경.

## 🔧 작업 내용
- PointController의 `/transactions`, `/balance`, `/refund` 엔드포인트에서 `Principal` 제거
- 각 메서드 파라미터에 `@RequestParam Long userId` 추가
- Swagger에서 userId 입력 가능하도록 API 명세 수정

## ✅ 체크리스트
- [] Swagger에서 userId를 입력해 호출 시 정상 응답 확인
- [] Postman 테스트 완료
- [ ] 테스트 후 운영 배포 시 기존 `Principal` 방식으로 원복 예정

## 📝 기타 참고 사항
- 운영 배포 시 인증 로직을 다시 적용해야 하며, 현재 코드는 테스트 전용입니다.
- 테스트 시 DB에 존재하는 userId 값을 입력해야 정상 동작합니다.

## 📎 관련 이슈
Close #235
