### PR TITLE
[FEAT] #238 add @RequestParam(name = userId)

### DIFF
--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -1,5 +1,6 @@
 package org.bobj.point.controller;
 
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -67,14 +68,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/point")
 @RequiredArgsConstructor
+@Api(tags = "포인트 API (테스트용)")
 public class PointController {
 
     private final PointService pointService;
 
     @GetMapping("/transactions")
     @ApiOperation(value = "포인트 입출금 내역 조회 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
+    @ApiImplicitParam(name = "userId", value = "사용자 ID", required = true, dataType = "long", paramType = "query")
     public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactionsForTest(
-        @RequestParam Long userId
+        @RequestParam(name = "userId") Long userId   // <-- 이름 명시
     ) {
         List<PointTransactionVO> transactions = pointService.findTransactionsByUserId(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
@@ -82,8 +85,9 @@ public class PointController {
 
     @GetMapping("/balance")
     @ApiOperation(value = "현재 포인트 보유량 조회 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
+    @ApiImplicitParam(name = "userId", value = "사용자 ID", required = true, dataType = "long", paramType = "query")
     public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalanceForTest(
-        @RequestParam Long userId
+        @RequestParam(name = "userId") Long userId   // <-- 이름 명시
     ) {
         BigDecimal balance = pointService.getTotalPoint(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
@@ -91,14 +95,15 @@ public class PointController {
 
     @PostMapping("/refund")
     @ApiOperation(value = "포인트 환급 요청 (테스트용)", notes = "userId를 파라미터로 받아 테스트합니다.")
-    @ApiResponses(value = {
+    @ApiResponses({
         @ApiResponse(code = 200, message = "환급 요청 성공", response = ApiCommonResponse.class),
         @ApiResponse(code = 400, message = "잘못된 요청 (잔액 부족 등)", response = ErrorResponse.class),
         @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
+    @ApiImplicitParam(name = "userId", value = "사용자 ID", required = true, dataType = "long", paramType = "query")
     public ResponseEntity<ApiCommonResponse<String>> requestRefundForTest(
-        @RequestParam Long userId,
-        @RequestBody RefundRequestDto refundRequestDto
+        @RequestParam(name = "userId") Long userId,  // <-- 이름 명시
+        @RequestBody @Valid RefundRequestDto refundRequestDto
     ) {
         pointService.requestRefund(userId, refundRequestDto.getAmount());
         return ResponseEntity.ok(ApiCommonResponse.createSuccess("환급 요청이 완료되었습니다."));


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
Swagger에서 `@RequestParam` 파라미터(userId)가 표시되지 않는 문제를 수정하여  
테스트 시 userId를 직접 입력할 수 있도록 개선.

## 🔧 작업 내용
- PointController의 테스트용 API 메서드(`transactions`, `balance`, `refund`)에 `@RequestParam(name = "userId")` 명시
- Swagger UI에서 파라미터가 보이도록 `@ApiImplicitParam` 추가
- Swagger 테스트 환경에서 userId 입력 가능 여부 확인

## ✅ 체크리스트
- [x] Swagger UI에서 userId 파라미터 입력란 정상 노출
- [x] 입력한 userId로 API 호출 시 정상 응답 확인
- [x] Postman으로 호출 테스트 완료

## 📝 기타 참고 사항
- 본 변경은 테스트 편의성을 위한 Swagger 전용 수정이며, 운영 배포 전에는 기존 `Principal` 기반 인증 방식으로 복원 필요.

## 📎 관련 이슈
Close #235
