### PR TITLE
[FEAT] #274 Update photo URL format in property detail API

### DIFF
--- a/src/main/java/org/bobj/property/dto/PhotoDTO.java
+++ b/src/main/java/org/bobj/property/dto/PhotoDTO.java
@@ -16,35 +16,9 @@ public class PhotoDTO {
     @ApiModelProperty(value = "사진 URL", example = "https://example.com/image.jpg")
     private String photoUrl;
 
-    public static PhotoDTO of(PropertyPhotoVO vo, S3Service s3Service) {
-        String url = vo.getPhotoUrl();
-
-        // 1. 테스트 URL이나 잘못된 값이면 기본 이미지 반환
-        if (url == null || url.contains("example.com")) {
-            return PhotoDTO.builder()
-                    .photoUrl("https://s3.example.com/photo1.jpg") // 로컬 기본 이미지 경로 또는 CDN 경로
-                    .build();
-        }
-
-        String key = getS3KeyFromUrl(url);
-
-        try {
-            String originalFilename = s3Service.getOriginalFilenameFromS3(key);
-            return PhotoDTO.builder()
-                    .photoUrl(s3Service.generatePresignedUrl(key, originalFilename))
-                    .build();
-        } catch (Exception e) {
-            // 2. S3에서 못 찾으면 기본 이미지 반환
-            return PhotoDTO.builder()
-                    .photoUrl("https://s3.example.com/photo1.jpg")
-                    .build();
-        }
-    }
-
-    // S3 키 추출 메서드 (내부에서만 사용되므로 private static)
-    // 예: https://s3.amazonaws.com/your-bucket/uploads/abc.pdf
-    // → uploads/abc.pdf 추출
-    private static String getS3KeyFromUrl(String url) {
-        return url.substring(url.indexOf(".com/") + 5);
+    public static PhotoDTO of(PropertyPhotoVO vo) {
+        return PhotoDTO.builder()
+                .photoUrl(vo.getPhotoUrl())
+                .build();
     }
 }

--- a/src/main/java/org/bobj/property/dto/PropertyDetailDTO.java
+++ b/src/main/java/org/bobj/property/dto/PropertyDetailDTO.java
@@ -105,15 +105,7 @@ public class PropertyDetailDTO {
                 .map(doc -> DocumentDTO.of(doc, s3Service))
                 .distinct()
                 .toList()
-                : List.of();
-
-        List<PhotoDTO> distinctPhotos = vo.getPhotos() != null
-                ? vo.getPhotos().stream()
-                .filter(photo -> Objects.nonNull(photo) && Objects.nonNull(photo.getPhotoId()))
-                .map(photo -> PhotoDTO.of(photo, s3Service))
-                .distinct()
-                .toList()
-                : List.of();
+                : List.of();;
 
         return PropertyDetailDTO.builder()
                 .propertyId(vo.getPropertyId())
@@ -144,7 +136,9 @@ public class PropertyDetailDTO {
                 .updatedAt(vo.getUpdatedAt())
                 .soldAt(vo.getSoldAt())
                 .documents(distinctDocuments)
-                .photos(distinctPhotos)
+                .photos(vo.getPhotos() != null
+                        ? vo.getPhotos().stream().map(PhotoDTO::of).collect(Collectors.toList())
+                        : List.of())
                 .tags(vo.getTags())
                 .build();
     }


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
현재 관리자, 매도자용 매물 상세 조회 API에서 이미지, 문서 모두 S3에 업로드된 url의 presigned url을 발급해서 다운로드 링크로 변환하여 url을 응답으로 보내주는 형식

문서는 지금과 같이 유지하고 이미지는 다운로드 형식 말고 DB에 저장해준 url 그대로 응답으로 보내서 매물 상세 페이지에서 이미지 볼 수 있는 형식으로 변환
## 🔧 작업 내용
- PhotoDTO
  presigned url 변환후 다운로드 형식으로 변환하는 로직 삭제
PropertyPhotoVO에서 url만 바로 넘겨줌
- PropertyDetailDTO
  photo에 연결되어있는 S3 로직 제거

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #274 
