### PR TITLE
Feature/#229

### DIFF
--- a/src/main/java/org/bobj/device/controller/UserDeviceTokenController.java
+++ b/src/main/java/org/bobj/device/controller/UserDeviceTokenController.java
@@ -7,11 +7,13 @@ import org.bobj.common.exception.ErrorResponse;
 import org.bobj.common.response.ApiCommonResponse;
 import org.bobj.device.dto.request.UserDeviceTokenRequestDTO;
 import org.bobj.device.service.UserDeviceTokenService;
+import org.bobj.user.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Log4j2
 @Api(tags = "디바이스 토큰 API")
@@ -19,21 +21,18 @@ public class UserDeviceTokenController {
 
     private final UserDeviceTokenService userDeviceTokenService;
 
-    @PostMapping("/users/{userId}/device-token")
+    @PostMapping("/device-tokens")
     @ApiOperation(value = "디바이스 토큰 등록/갱신", notes = "사용자의 푸시 알림을 위한 디바이스 토큰을 등록하거나 갱신합니다.")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "userId", value = "디바이스 토큰을 등록할 사용자 ID", required = true, dataType = "long", paramType = "path")
-    })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "디바이스 토큰 등록 성공", response = ApiCommonResponse.class),
             @ApiResponse(code = 400, message = "잘못된 요청 (예: 토큰 값 누락)", response = ErrorResponse.class),
             @ApiResponse(code = 404, message = "사용자를 찾을 수 없음", response = ErrorResponse.class)
     })
     public ResponseEntity<ApiCommonResponse<String>> registerDeviceToken(
-            @PathVariable @ApiParam(value = "사용자 ID", required = true) Long userId,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestBody @ApiParam(value = "디바이스 토큰 DTO", required = true) UserDeviceTokenRequestDTO requestDTO
     ) {
-        log.debug("디바이스 토큰 등록 요청 - userId: {}, token: {}", userId, requestDTO.getDeviceToken());
+        Long userId = principal.getUserId();
 
         // 서비스 레이어에서 토큰 등록/갱신 로직 처리
         userDeviceTokenService.registerToken(userId, requestDTO.getDeviceToken());

--- a/src/main/java/org/bobj/order/dto/request/OrderRequestDTO.java
+++ b/src/main/java/org/bobj/order/dto/request/OrderRequestDTO.java
@@ -18,9 +18,6 @@ import java.math.BigDecimal;
 @ApiModel(description = "거래 주문 등록 요청 DTO")
 public class OrderRequestDTO {
 
-    @ApiModelProperty(value = "사용자 ID", example = "1", required = true)
-    private Long userId;
-
     @ApiModelProperty(value = "펀딩 ID", example = "1", required = true)
     private Long fundingId;
 
@@ -35,7 +32,6 @@ public class OrderRequestDTO {
 
     public OrderVO toVo() {
         return OrderVO.builder()
-                .userId(userId)
                 .fundingId(fundingId)
                 .orderType(OrderType.valueOf(orderType))
                 .orderPricePerShare(orderPricePerShare)

--- a/src/main/java/org/bobj/order/service/OrderService.java
+++ b/src/main/java/org/bobj/order/service/OrderService.java
@@ -10,7 +10,7 @@ public interface OrderService {
 
     OrderResponseDTO getOrderById(Long orderId);
 
-    OrderResponseDTO placeOrder(OrderRequestDTO orderRequestDTO);
+    OrderResponseDTO placeOrder(Long userId, OrderRequestDTO orderRequestDTO);
 
     List<OrderResponseDTO> getOrderHistoryByUserId(Long userId, String orderType);
 

--- a/src/main/java/org/bobj/order/service/OrderServiceImpl.java
+++ b/src/main/java/org/bobj/order/service/OrderServiceImpl.java
@@ -49,9 +49,11 @@ public class OrderServiceImpl implements OrderService {
 
     @Transactional
     @Override
-    public OrderResponseDTO placeOrder(OrderRequestDTO orderRequestDTO) {
+    public OrderResponseDTO placeOrder(Long userId, OrderRequestDTO orderRequestDTO) {
 
         OrderVO orderVO = orderRequestDTO.toVo();
+
+        orderVO.setUserId(userId);
 
         // 1. 펀딩 상태 확인
 //        String fundingStatus = mapper.findFundingStatusByFundingId(orderBookVO.getFundingId());

--- a/src/main/java/org/bobj/share/controller/ShareController.java
+++ b/src/main/java/org/bobj/share/controller/ShareController.java
@@ -7,23 +7,24 @@ import org.bobj.common.exception.ErrorResponse;
 import org.bobj.common.response.ApiCommonResponse;
 import org.bobj.share.dto.response.ShareResponseDTO;
 import org.bobj.share.service.ShareService;
+import org.bobj.user.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/shares")
+@RequestMapping("/api/auth/shares")
 @RequiredArgsConstructor
 @Log4j2
 @Api(tags="지분 API")
 public class ShareController {
     private final ShareService shareService;
 
-    @GetMapping("/users/{userId}") // 엔드포인트 정의
+    @GetMapping // 엔드포인트 정의
     @ApiOperation(value = "사용자 보유 지분 조회", notes = "특정 사용자가 보유한 모든 주식 지분 정보를 조회합니다.")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "userId", value = "조회할 사용자 ID", required = true, dataType = "long", paramType = "path"),
             @ApiImplicitParam(name = "page", value = "페이지 번호 (0부터 시작)", defaultValue = "0", dataType = "int", paramType = "query"),
             @ApiImplicitParam(name = "size", value = "한 페이지당 항목 수", defaultValue = "10", dataType = "int", paramType = "query")
     })
@@ -33,10 +34,11 @@ public class ShareController {
             @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
     public ResponseEntity<ApiCommonResponse<List<ShareResponseDTO>>> getUserShares(
-            @PathVariable @ApiParam(value = "사용자 ID", required = true) Long userId,
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
+        Long userId = principal.getUserId();
         List<ShareResponseDTO> userShares = shareService.getSharesByUserIdPaging(userId, page, size);
 
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(userShares));

--- a/src/main/java/org/bobj/share/controller/ShareController.java
+++ b/src/main/java/org/bobj/share/controller/ShareController.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class ShareController {
     private final ShareService shareService;
 
-    @GetMapping // 엔드포인트 정의
+    @GetMapping("") // 엔드포인트 정의
     @ApiOperation(value = "사용자 보유 지분 조회", notes = "특정 사용자가 보유한 모든 주식 지분 정보를 조회합니다.")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "page", value = "페이지 번호 (0부터 시작)", defaultValue = "0", dataType = "int", paramType = "query"),


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
= API의 보안 강화를 위해 인증된 사용자의 ID를 UserPrincipal에서 가져오는 방식으로 리팩토링했습니다.

- 이에 따라, 클라이언트 요청(Request) DTO나 URL 경로에서 userId를 제거하고, 인증이 필요한 API의 엔드포인트를 /api/auth/** 경로로 변경했습니다.

## 🔧 작업 내용
- 변경된 api 경로
- 거래
   - 거래 주문 등록 
     POST /order-books -> /api/auth/order-books
   - 거래 주문 내역 조회
     GET /order-books/history/{userId} -> /api/auth/order-books/history
   - 거래 주문 취소  /order-books/{orderId} -> /api/auth/order-books/{orderId}
      PATCH 
- 지분
   - 보유 지분 조회
      GET /api/shares/users/{userId} -> /api/auth/shares
- 알림
   - 디바이스 토큰 등록
     POST   /api/users/{userId}/device-tokens -> /api/auth/device-tokens
  - 알림 조회  
     GET  /api/notifications -> /api/auth/notifications
  - 알림 읽음
     PUT /api/notifications/{notificationId}/read -> /api/auth/notifications/{notificationId}/read
             /api/notifications/read-all -> /api/auth/notifications/read-all
## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #228
