### PR TITLE
[REFACTOR] #286 use UserPrincipal && change api endPoint

### DIFF
--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -1,4 +1,3 @@
-
 package org.bobj.point.controller;
 
 import io.swagger.annotations.*;
@@ -11,14 +10,19 @@ import org.bobj.payment.service.PaymentService;
 import org.bobj.point.domain.PointChargeRequestVO;
 import org.bobj.point.service.PointChargeRequestService;
 import org.bobj.point.util.MerchantUidGenerator;
+import org.bobj.user.security.UserPrincipal;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal; // ★ 추가
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
-import java.security.Principal;
+import springfox.documentation.annotations.ApiIgnore;
+
+// (프로젝트 내) 인증 사용자 객체
 
 @RestController
-@RequestMapping("/api/point")
+@RequestMapping("/api/auth/point")
 @RequiredArgsConstructor
 @Log4j2
 @Api(tags = "포인트 충전 및 검증 API")
@@ -27,48 +31,24 @@ public class PointChargeRequestController {
     private final PointChargeRequestService pointChargeRequestService;
     private final PaymentService paymentService;
 
-//    @PostMapping("/charge")
-//    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
-//    @ApiResponses(value = {
-//        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
-//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
-//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-//    })
-//    public ResponseEntity<ApiCommonResponse<String>> createCharge(
-//        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
-//        Principal principal
-//    ) {
-//        Long userId = Long.parseLong(principal.getName());
-//        String merchantUid = MerchantUidGenerator.generate(userId);
-//
-//        PointChargeRequestVO request = PointChargeRequestVO.builder()
-//            .userId(userId)
-//            .amount(amount)
-//            .merchantUid(merchantUid)
-//            .status("PENDING")
-//            .build();
-//
-//        pointChargeRequestService.createChargeRequest(request);
-//        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
-//
-//        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
-//    }
-
-
     @PostMapping("/charge")
     @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
         @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 401, message = "인증 필요", response = ErrorResponse.class),
         @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
     public ResponseEntity<ApiCommonResponse<String>> createCharge(
-        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount
-        // Principal principal ← 제거
+        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
+        @ApiIgnore @AuthenticationPrincipal UserPrincipal principal // ★ 변경
     ) {
-        // TODO: 실제 배포 시 제거
-        Long userId = 1L; // 임시 테스트용 사용자 ID
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body((ApiCommonResponse<String>) ApiCommonResponse.createError("인증이 필요합니다."));
+        }
 
+        Long userId = principal.getUserId(); // ★ 변경
         String merchantUid = MerchantUidGenerator.generate(userId);
 
         PointChargeRequestVO request = PointChargeRequestVO.builder()
@@ -84,61 +64,24 @@ public class PointChargeRequestController {
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
     }
 
-
-
-
-
-
-
-
-//    @PostMapping("/verify")
-//    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
-//    @ApiResponses(value = {
-//        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
-//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)\n\n" +
-//            "**예시:**\n" +
-//            "```json\n" +
-//            "{\n" +
-//            "  \"status\": 400,\n" +
-//            "  \"code\": \"P001\",\n" +
-//            "  \"message\": \"결제 금액이 일치하지 않습니다.\",\n" +
-//            "  \"path\": \"/api/point/verify\"\n" +
-//            "}\n" +
-//            "```",
-//            response = ErrorResponse.class),
-//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-//    })
-//    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
-//        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
-//        VerifyRequestDto requestDto,
-//        Principal principal
-//    ) {
-//        Long userId = Long.parseLong(principal.getName());
-//        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
-//
-//        paymentService.verifyPayment(userId, requestDto);
-//
-//        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
-//    }
-//}
-
-
     @PostMapping("/verify")
-    public ResponseEntity<?> verifyPayment(@RequestBody VerifyRequestDto dto) {
-        Long testUserId = 1L; // 실제 로그인 구현 전 테스트용 하드코딩
-
-        paymentService.verifyPayment(testUserId, dto);
-
-        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
-    }
-
-
+    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 401, message = "인증 필요", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
     public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
-        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
-        VerifyRequestDto requestDto,
-        Principal principal
+        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true) VerifyRequestDto requestDto,
+        @ApiIgnore @AuthenticationPrincipal UserPrincipal principal // ★ 변경
     ) {
-        Long userId = Long.parseLong(principal.getName());
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body((ApiCommonResponse<String>) ApiCommonResponse.createError("인증이 필요합니다."));
+        }
+
+        Long userId = principal.getUserId(); // ★ 변경
         log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
 
         paymentService.verifyPayment(userId, requestDto);
@@ -146,88 +89,3 @@ public class PointChargeRequestController {
         return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
     }
 }
-//package org.bobj.point.controller;
-//
-//import io.swagger.annotations.*;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.log4j.Log4j2;
-//import org.bobj.common.exception.ErrorResponse;
-//import org.bobj.common.response.ApiCommonResponse;
-//import org.bobj.payment.dto.VerifyRequestDto;
-//import org.bobj.payment.service.PaymentService;
-//import org.bobj.point.domain.PointChargeRequestVO;
-//import org.bobj.point.service.PointChargeRequestService;
-//import org.bobj.point.util.MerchantUidGenerator;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//import java.math.BigDecimal;
-//import java.security.Principal;
-//
-//@RestController
-//@RequestMapping("/api/point")
-//@RequiredArgsConstructor
-//@Log4j2
-//@Api(tags = "포인트 충전 및 검증 API")
-//public class PointChargeRequestController {
-//
-//    private final PointChargeRequestService pointChargeRequestService;
-//    private final PaymentService paymentService;
-//
-//    @PostMapping("/charge")
-//    @ApiOperation(value = "포인트 충전 요청", notes = "사용자가 지정한 금액으로 포인트 충전 요청을 생성합니다.")
-//    @ApiResponses(value = {
-//        @ApiResponse(code = 200, message = "충전 요청 성공", response = ApiCommonResponse.class),
-//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 누락 등)", response = ErrorResponse.class),
-//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-//    })
-//    public ResponseEntity<ApiCommonResponse<String>> createCharge(
-//        @RequestParam @ApiParam(value = "충전 금액", example = "5000", required = true) BigDecimal amount,
-//        Principal principal
-//    ) {
-//        Long userId = Long.parseLong(principal.getName());
-//        String merchantUid = MerchantUidGenerator.generate(userId);
-//
-//        PointChargeRequestVO request = PointChargeRequestVO.builder()
-//            .userId(userId)
-//            .amount(amount)
-//            .merchantUid(merchantUid)
-//            .status("PENDING")
-//            .build();
-//
-//        pointChargeRequestService.createChargeRequest(request);
-//        log.info("포인트 충전 요청 생성: userId={}, amount={}, merchantUid={}", userId, amount, merchantUid);
-//
-//        return ResponseEntity.ok(ApiCommonResponse.createSuccess(merchantUid));
-//    }
-//
-//    @PostMapping("/verify")
-//    @ApiOperation(value = "결제 검증 및 포인트 지급", notes = "imp_uid를 통해 결제를 검증하고, 결제가 성공한 경우 포인트를 지급합니다.")
-//    @ApiResponses(value = {
-//        @ApiResponse(code = 200, message = "포인트 충전 성공", response = ApiCommonResponse.class),
-//        @ApiResponse(code = 400, message = "잘못된 요청 (금액 불일치, 결제 실패, 중복 처리 등)\n\n" +
-//            "**예시:**\n" +
-//            "```json\n" +
-//            "{\n" +
-//            "  \"status\": 400,\n" +
-//            "  \"code\": \"P001\",\n" +
-//            "  \"message\": \"결제 금액이 일치하지 않습니다.\",\n" +
-//            "  \"path\": \"/api/point/verify\"\n" +
-//            "}\n" +
-//            "```",
-//            response = ErrorResponse.class),
-//        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
-//    })
-//    public ResponseEntity<ApiCommonResponse<String>> verifyPayment(
-//        @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true)
-//        VerifyRequestDto requestDto,
-//        Principal principal
-//    ) {
-//        Long userId = Long.parseLong(principal.getName());
-//        log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
-//
-//        paymentService.verifyPayment(userId, requestDto);
-//
-//        return ResponseEntity.ok(ApiCommonResponse.createSuccess("포인트 충전 성공"));
-//    }
-//}

--- a/src/main/java/org/bobj/point/controller/PointController.java
+++ b/src/main/java/org/bobj/point/controller/PointController.java
@@ -10,11 +10,14 @@ import org.bobj.common.response.ApiCommonResponse;
 import org.bobj.point.RefundRequestDto;
 import org.bobj.point.domain.PointTransactionVO;
 import org.bobj.point.service.PointService;
+import org.bobj.user.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
-@RequestMapping("/api/point")
+@RequestMapping("/api/auth/point")
 @RequiredArgsConstructor
 @Api(tags = "포인트 API ")
 public class PointController {
@@ -22,59 +25,70 @@ public class PointController {
     private final PointService pointService;
 
     /**
-     * 포인트 입출금 내역 조회 (테스트용)
-     * GET /api/point/transactions-test?userId=1
+     * 포인트 입출금 내역 조회
+     * GET /api/auth/point/transactions?userId=1
      */
-    @GetMapping("/transactions-test")
+    @GetMapping("/transactions")
     @ApiOperation(
-        value = "포인트 입출금 내역 조회 (테스트용)",
-        notes = "userId를 쿼리 파라미터로 받아 테스트합니다."
+        value = "포인트 입출금 내역 조회",
+        notes = "인증된 사용자의 포인트 입출금 내역을 반환합니다."
     )
-    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactionsForTest(
-        @ApiParam(value = "사용자 ID", required = true, example = "1")
-        @RequestParam(name = "userId") Long userId
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "조회 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 401, message = "인증 필요", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<List<PointTransactionVO>>> getTransactions(
+        @ApiIgnore @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Long userId = principal.getUserId();
         List<PointTransactionVO> transactions = pointService.findTransactionsByUserId(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(transactions));
     }
 
     /**
-     * 현재 포인트 보유량 조회 (테스트용)
-     * GET /api/point/balance-test?userId=1
+     * 현재 포인트 보유량 조회
+     * GET /api/point/balance?userId=1
      */
-    @GetMapping("/balance-test")
+    @GetMapping("/balance")
     @ApiOperation(
-        value = "현재 포인트 보유량 조회 (테스트용)",
-        notes = "userId를 쿼리 파라미터로 받아 테스트합니다."
+        value = "현재 포인트 보유량 조회",
+        notes = "인증된 사용자의 현재 포인트 보유량을 반환합니다."
     )
-    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalanceForTest(
-        @ApiParam(value = "사용자 ID", required = true, example = "1")
-        @RequestParam(name = "userId") Long userId
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "조회 성공", response = ApiCommonResponse.class),
+        @ApiResponse(code = 401, message = "인증 필요", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
+    })
+    public ResponseEntity<ApiCommonResponse<BigDecimal>> getPointBalance(
+        @ApiIgnore @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Long userId = principal.getUserId();
         BigDecimal balance = pointService.getTotalPoint(userId);
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(balance));
     }
 
     /**
-     * 포인트 환급 요청 (테스트용)
-     * POST /api/point/refund-test?userId=1
+     * 포인트 환급 요청
+     * POST /api/point/refund?userId=1
      * Body: { "amount": 5000 }
      */
-    @PostMapping("/refund-test")
+    @PostMapping("/refund")
     @ApiOperation(
-        value = "포인트 환급 요청 (테스트용)",
-        notes = "userId를 쿼리 파라미터로 받아 테스트합니다."
+        value = "포인트 환급 요청",
+        notes = "인증된 사용자의 포인트 환급을 요청합니다."
     )
     @ApiResponses({
         @ApiResponse(code = 200, message = "환급 요청 성공", response = ApiCommonResponse.class),
         @ApiResponse(code = 400, message = "잘못된 요청 (잔액 부족 등)", response = ErrorResponse.class),
+        @ApiResponse(code = 401, message = "인증 필요", response = ErrorResponse.class),
         @ApiResponse(code = 500, message = "서버 내부 오류", response = ErrorResponse.class)
     })
-    public ResponseEntity<ApiCommonResponse<String>> requestRefundForTest(
-        @ApiParam(value = "사용자 ID", required = true, example = "1")
-        @RequestParam(name = "userId") Long userId,
+    public ResponseEntity<ApiCommonResponse<String>> requestRefund(
+        @ApiIgnore @AuthenticationPrincipal UserPrincipal principal,
         @RequestBody @Valid RefundRequestDto refundRequestDto
     ) {
+        Long userId = principal.getUserId();
         pointService.requestRefund(userId, refundRequestDto.getAmount());
         return ResponseEntity.ok(ApiCommonResponse.createSuccess("환급 요청이 완료되었습니다."));
     }


### PR DESCRIPTION
# [REFACTOR] #286 Use UserPrincipal & unify Point endpoints under `/api/auth/point/**`

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

---

## 📌 개요
- Point 도메인 API를 **인증 전제 경로**로 일원화: `/api/auth/point/**`
- 컨트롤러에서 `@RequestParam userId` 제거 → **`@AuthenticationPrincipal UserPrincipal` 기반**으로 변경
- Swagger에서 `UserPrincipal` 파라미터가 노출되지 않도록 **숨김 처리**

---

## 🔧 작업 내용
- **Controller**
  - 클래스 경로 통일: `PointController`, `PointChargeRequestController` → `/api/auth/point`
  - 메서드 변경:
    - `transactions / balance / refund / charge / verify` 에 `@AuthenticationPrincipal UserPrincipal` 적용
    - `principal == null` 시 401 반환 가드 추가
    - 기존 `@RequestParam Long userId` 제거
- **Swagger (springfox 2.x)**
  -  각 메서드 파라미터에 `@ApiIgnore` 적용  
- **엔드포인트 매핑 정리**
  - `/api/point/transactions-test` → `GET /api/auth/point/transactions`
  - `/api/point/balance-test` → `GET /api/auth/point/balance`
  - `/api/point/refund-test` → `POST /api/auth/point/refund`
  - `/api/point/charge` → `POST /api/auth/point/charge`
  - `/api/point/verify` → `POST /api/auth/point/verify`
  - **예외(외부 콜백)**: `POST /api/public/point/webhook` (변경 없음)

---


