### PR TITLE
[FEAT] #313 Add funding_id property to get sold property list API

### DIFF
--- a/src/main/java/org/bobj/property/dto/PropertySoldResponseDTO.java
+++ b/src/main/java/org/bobj/property/dto/PropertySoldResponseDTO.java
@@ -21,4 +21,6 @@ public class PropertySoldResponseDTO {
     private String title;
     @ApiModelProperty("누적 수익률")
     private BigDecimal cumulativeReturn;
+    @ApiModelProperty("펀딩 ID")
+    private Long fundingId;
 }

--- a/src/main/resources/org/bobj/property/mapper/PropertyMapper.xml
+++ b/src/main/resources/org/bobj/property/mapper/PropertyMapper.xml
@@ -194,14 +194,18 @@
              FROM property_photos
              WHERE property_id = p.property_id
              ORDER BY created_at ASC
-             LIMIT 1) AS thumbnail_url
+             LIMIT 1) AS thumbnail_url,
+            f.funding_id
         FROM properties p
+        LEFT JOIN fundings f
+            ON f.property_id = p.property_id
         WHERE p.status = 'SOLD'
         ORDER BY p.sold_at DESC
     </select>
 
     <resultMap id="PropertySoldMap" type="org.bobj.property.dto.PropertySoldResponseDTO">
         <id property="propertyId" column="property_id"/>
+        <id property="fundingId" column="funding_id"/>
         <result property="title" column="title"/>
         <result property="cumulativeReturn" column="cumulative_return"/>
         <association property="thumbnail" javaType="org.bobj.property.dto.PhotoDTO">


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
매각 완료 매물 조회 API 응답에 funding_id 속성 추가

## 🔧 작업 내용
PropertyMapper.xml에 join문 추가 및 DTO에 funding_id 속성 추가 

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #313 
