### PR TITLE
[REFACTOR] 주문 체결 로직 리팩토링

### DIFF
--- a/src/main/java/org/bobj/config/RootConfig.java
+++ b/src/main/java/org/bobj/config/RootConfig.java
@@ -47,11 +47,12 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         "org.bobj.allocation.mapper",
 })
 @ComponentScan(basePackages = "org.bobj")
-@EnableTransactionManagement
+@EnableTransactionManagement(proxyTargetClass = true)
 @Import({
         AppConfig.class,
         OAuth2ClientConfig.class,
-        S3Config.class
+        S3Config.class,
+        RedisConfig.class
 })
 @EnableScheduling
 

--- a/src/main/java/org/bobj/config/ServletConfig.java
+++ b/src/main/java/org/bobj/config/ServletConfig.java
@@ -28,7 +28,8 @@ import org.springframework.web.servlet.view.JstlView;
         "org.bobj.device.controller",
         "org.bobj.fcm.controller",
         "org.bobj.device.controller",
-        "org.bobj.allocation.controller"
+        "org.bobj.allocation.controller",
+        "org.bobj.order.consumer"
         })
 
 public class ServletConfig implements WebMvcConfigurer {

--- a/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
+++ b/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
@@ -6,63 +6,136 @@ import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.order.domain.OrderVO;
 import org.bobj.order.mapper.OrderMapper;
 import org.bobj.order.service.OrderMatchingService;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Log4j2
-public class OrderQueueConsumer {
+public class OrderQueueConsumer  implements MessageListener {
     private final RedisTemplate<String, Object> redisTemplate;
     private final OrderMapper orderMapper;
     private final OrderMatchingService orderMatchingService;
-    private final FundingMapper fundingMapper;
 
-    // 매 10초마다 Redis 큐에서 주문 ID 꺼내서 처리
-    @Scheduled(fixedDelay = 10000)
-    public void consumeOrders() {
-        for (Long fundingId : getTrackedFundingIds()) {
-            String queueKey = "order:queue:" + fundingId;
-            String processingQueueKey = "processing:order:queue:" + fundingId;
+    // Pub/Sub 메시지를 처리하는 메서드
+    @Override
+    @Transactional
+    public void onMessage(Message message, byte[] pattern) {
+        String fundingIdStr = (String) redisTemplate.getStringSerializer().deserialize(message.getBody());
+        if (fundingIdStr != null) {
+            fundingIdStr = fundingIdStr.replaceAll("\"", "");
+        }
+        if (fundingIdStr == null || fundingIdStr.isEmpty()) {
+            log.warn("수신된 메시지 내용이 비어있습니다.");
+            return;
+        }
+
+        Long fundingId = Long.valueOf(fundingIdStr);
+        log.info("🎉 새로운 주문 이벤트 수신. 체결 시작 (fundingId={})", fundingId);
+
+        String queueKey = "order:queue:" + fundingId;
+        String processingQueueKey = "processing:order:queue:" + fundingId;
+        final int LOOP_LIMIT = 500;
+        int loop = 0;
+
+        while (true) {
+            if (++loop > LOOP_LIMIT) {
+                log.warn("루프 상한 도달 → 중단 (fundingId={})", fundingId);
+                break;
+            }
 
             Object orderIdObj = redisTemplate.opsForList().rightPopAndLeftPush(queueKey, processingQueueKey);
-            if (orderIdObj == null) continue;
+            if (orderIdObj == null) {
+                log.info("큐 비었음 → 종료 (fundingId={})", fundingId);
+                break;
+            }
+
+            String orderIdStr = orderIdObj.toString();
             try {
-                Long orderId = Long.valueOf(orderIdObj.toString());
+                Long orderId = Long.valueOf(orderIdStr);
                 OrderVO order = orderMapper.get(orderId);
-
                 if (order == null) {
-                    throw new IllegalArgumentException("주문 ID 찾을 수 없음: " + orderId);
+                    redisTemplate.opsForList().remove(processingQueueKey, 1, orderIdObj);
+                    log.warn("주문 없음 → drop (orderId={})", orderId);
+                    continue;
                 }
 
-                int remainingCount = orderMatchingService.processOrderMatching(order);
-//                orderMatchingService.processOrderMatching(order);
+                int requested = order.getOrderShareCount();
+                int remaining = orderMatchingService.processOrderMatching(order);
 
-                if (remainingCount > 0) {
-                    // 아직 체결되지 않은 수량이 남아있으면 다시 큐에 넣기
-                    redisTemplate.opsForList().rightPush(queueKey, orderId); // FIFO 유지
-                    log.info("🔁 주문 일부 체결됨. 재큐잉 (orderId={}, remaining={})", orderId, remainingCount);
-                }
+                // DB에서 최신 상태 다시 조회 (체결 후 반영된 잔여 수량 확인)
+                order = orderMapper.get(orderId);
+                remaining = order.getRemainingShareCount();
 
-                // 처리 완료 시 처리 중 큐에서 주문 ID 삭제
+                // 처리중 큐에서 제거
                 redisTemplate.opsForList().remove(processingQueueKey, 1, orderIdObj);
 
-                log.info("✅ 주문 처리 완료 (주문 ID: {})", orderId);
-            } catch (Exception e) {
-                log.error("❗ 주문 처리 실패: {}", e.getMessage());
+                if (remaining > 0) {
+                    // 부분/미체결 → 이번 라운드 재큐잉하지 않음
+                    log.info("⏸️ 부분 체결 → 다음 라운드에서 재시도 (orderId={}, remaining={})", orderId, remaining);
+                } else {
+                    log.info("✅ 완전 체결 → 큐에서 제거 (orderId={})", orderId);
+                }
 
-                // 처리 실패 시, 처리 중 큐에서 다시 원래 큐로 복귀
-                Object popped = redisTemplate.opsForList().rightPopAndLeftPush(processingQueueKey, queueKey);
+                boolean progressed = (remaining < requested);
+                if (!progressed) {
+                    log.info("⏸️ 이번 라운드 진전 없음 → 종료 (orderId={})", orderId);
+                    break;
+                }
+
+            } catch (Exception e) {
+                log.error("처리 실패: {}", e.getMessage(), e);
+                redisTemplate.opsForList().rightPopAndLeftPush(processingQueueKey, queueKey);
+                break;
             }
         }
     }
 
-    private Long[] getTrackedFundingIds() {
-        List<Long> ids = fundingMapper.findAllFundingIds();
-        return ids.toArray(new Long[0]);
-    }
+ //매 10초마다 Redis 큐에서 주문 ID 꺼내서 처리
+//    @Scheduled(fixedDelay = 10000)
+//    public void consumeOrders() {
+//        for (Long fundingId : getTrackedFundingIds()) {
+//            String queueKey = "order:queue:" + fundingId;
+//            String processingQueueKey = "processing:order:queue:" + fundingId;
+//
+//            Object orderIdObj = redisTemplate.opsForList().rightPopAndLeftPush(queueKey, processingQueueKey);
+//            if (orderIdObj == null) continue;
+//            try {
+//                Long orderId = Long.valueOf(orderIdObj.toString());
+//                OrderVO order = orderMapper.get(orderId);
+//
+//                if (order == null) {
+//                    throw new IllegalArgumentException("주문 ID 찾을 수 없음: " + orderId);
+//                }
+//
+//                int remainingCount = orderMatchingService.processOrderMatching(order);
+//                orderMatchingService.processOrderMatching(order);
+//
+//                if (remainingCount > 0) {
+//                    // 아직 체결되지 않은 수량이 남아있으면 다시 큐에 넣기
+//                    redisTemplate.opsForList().rightPush(queueKey, orderId); // FIFO 유지
+//                    log.info("🔁 주문 일부 체결됨. 재큐잉 (orderId={}, remaining={})", orderId, remainingCount);
+//                }
+//
+//                // 처리 완료 시 처리 중 큐에서 주문 ID 삭제
+//                redisTemplate.opsForList().remove(processingQueueKey, 1, orderIdObj);
+//
+//                log.info("✅ 주문 처리 완료 (주문 ID: {})", orderId);
+//            } catch (Exception e) {
+//                log.error("❗ 주문 처리 실패: {}", e.getMessage());
+//
+//                // 처리 실패 시, 처리 중 큐에서 다시 원래 큐로 복귀
+//                Object popped = redisTemplate.opsForList().rightPopAndLeftPush(processingQueueKey, queueKey);
+//            }
+//        }
+//    }
+//
+//    private Long[] getTrackedFundingIds() {
+//        List<Long> ids = fundingMapper.findAllFundingIds();
+//        return ids.toArray(new Long[0]);
+//    }
+
 }

--- a/src/main/java/org/bobj/order/controller/OrderController.java
+++ b/src/main/java/org/bobj/order/controller/OrderController.java
@@ -102,15 +102,6 @@ public class OrderController {
 
         //소켓 메세지 pub
         publishOrderBookUpdate(created.getFundingId());
-//        try {
-//            OrderBookResponseDTO orderBook = orderBookService.getOrderBookByFundingId(created.getFundingId());
-//            String destination = "/topic/order-book/" + created.getFundingId();
-//
-//            messagingTemplate.convertAndSend(destination, orderBook);
-//            log.info("Order book update published to topic {}: {}", destination, orderBook);
-//        } catch (Exception e) {
-//            log.error("Failed to publish order book update for fundingId {}: {}", created.getFundingId(), e.getMessage(), e);
-//        }
 
         return ResponseEntity.ok(response);
     }
@@ -152,15 +143,6 @@ public class OrderController {
     public ResponseEntity<ApiCommonResponse<String>> cancelOrder(@PathVariable Long orderId) {
         Long fundingId = service.cancelOrder(orderId);
 
-//        try {
-//            OrderBookResponseDTO orderBook = orderBookService.getOrderBookByFundingId(fundingId);
-//            String destination = "/topic/order-book/" + fundingId;
-//
-//            messagingTemplate.convertAndSend(destination, orderBook);
-//            log.info("Order book update published to topic {}: {}", destination, orderBook);
-//        } catch (Exception e) {
-//            log.error("Failed to publish order book update for fundingId {}: {}", fundingId, e.getMessage(), e);
-//        }
         //소켓 메세지 pub
         publishOrderBookUpdate(fundingId);
 

--- a/src/main/java/org/bobj/order/event/OrderPlacedEvent.java
+++ b/src/main/java/org/bobj/order/event/OrderPlacedEvent.java
@@ -1,0 +1,11 @@
+package org.bobj.order.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OrderPlacedEvent {
+    private final Long fundingId;
+    private final Long orderId;
+}

--- a/src/main/java/org/bobj/order/event/OrderPlacedEventHandler.java
+++ b/src/main/java/org/bobj/order/event/OrderPlacedEventHandler.java
@@ -1,0 +1,21 @@
+package org.bobj.order.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.bobj.order.producer.OrderQueueProducer;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class OrderPlacedEventHandler {
+    private final OrderQueueProducer orderQueueProducer;       // Redis 리스트 push
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(OrderPlacedEvent e) {
+        orderQueueProducer.pushOrder(e.getFundingId(), e.getOrderId());
+    }
+}

--- a/src/main/java/org/bobj/order/producer/OrderQueueProducer.java
+++ b/src/main/java/org/bobj/order/producer/OrderQueueProducer.java
@@ -1,19 +1,28 @@
 package org.bobj.order.producer;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+@Log4j2
 @Component
 @RequiredArgsConstructor
 public class OrderQueueProducer {
 
-    private static final String ORDER_QUEUE_PREFIX = "order:queue:";
-
     private final RedisTemplate<String, Object> redisTemplate;
 
+    private static final String ORDER_QUEUE_PREFIX = "order:queue:";
+
+    private static final String ORDER_EVENT_CHANNEL = "order:events";
+
     public void pushOrder(Long fundingId, Long orderId) {
-        String key = ORDER_QUEUE_PREFIX + fundingId;
-        redisTemplate.opsForList().rightPush(key, orderId);
+        String queueKey = ORDER_QUEUE_PREFIX + fundingId;
+
+        redisTemplate.opsForList().leftPush(queueKey, orderId);
+        log.info("🛒 주문이 대기 큐에 추가되었습니다. (fundingId={}, orderId={})", fundingId, orderId);
+
+        redisTemplate.convertAndSend(ORDER_EVENT_CHANNEL, String.valueOf(fundingId));
+        log.info("📢 Redis Pub/Sub 채널에 주문 발생 이벤트 발행. (channel={}, fundingId={})", ORDER_EVENT_CHANNEL, fundingId);
     }
 }

--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -2,16 +2,12 @@ package org.bobj.order.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.bobj.device.service.UserDeviceTokenService;
 import org.bobj.funding.service.FundingService;
-import org.bobj.fcm.dto.request.FcmRequestDto;
-import org.bobj.fcm.service.FcmService;
 import org.bobj.notification.service.NotificationService;
 import org.bobj.order.domain.OrderVO;
 import org.bobj.order.domain.OrderType;
 import org.bobj.order.mapper.OrderMapper;
 import org.bobj.orderbook.service.OrderBookService;
-import org.bobj.orderbook.service.OrderBookWebSocketService;
 import org.bobj.point.domain.PointVO;
 import org.bobj.point.service.PointService;
 import org.bobj.share.domain.ShareVO;
@@ -21,7 +17,6 @@ import org.bobj.trade.mapper.TradeMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,36 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-  <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout charset="UTF-8" pattern="%-5level %c(%M:%L) - %m%n"/>
-    </Console>
-  </Appenders>
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout charset="UTF-8" pattern="%-5level %c(%M:%L) - %m%n"/>
+        </Console>
+    </Appenders>
 
-  <Loggers>
-    <!-- 루트 로거 -->
-    <Root level="INFO">
-      <AppenderRef ref="console"/>
-    </Root>
+    <Loggers>
+        <!-- 루트 로거 -->
+        <Root level="INFO">
+            <AppenderRef ref="console"/>
+        </Root>
 
-    <!-- 스프링 프레임워크 로그 레벨 DEBUG로 올리기 -->
-    <Logger name="org.springframework" level="DEBUG" additivity="false">
-      <AppenderRef ref="console"/>
-    </Logger>
+        <!-- 스프링 프레임워크 로그 레벨 DEBUG로 올리기 -->
+        <Logger name="org.springframework" level="DEBUG" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
 
-    <!-- MyBatis 로그 레벨 DEBUG로 올리기 -->
-    <Logger name="org.apache.ibatis" level="DEBUG" additivity="false">
-      <AppenderRef ref="console"/>
-    </Logger>
+        <!-- MyBatis 로그 레벨 DEBUG로 올리기 -->
+        <Logger name="org.apache.ibatis" level="DEBUG" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
 
-    <!-- MyBatis 관련 로깅(옵션) -->
-    <Logger name="org.mybatis" level="DEBUG" additivity="false">
+        <!-- MyBatis 관련 로깅(옵션) -->
+        <Logger name="org.mybatis" level="DEBUG" additivity="false">
 
-    <logger name="org.bobj.common.crypto" level="DEBUG" />
-    <logger name="org.bobj.user.service" level="DEBUG" />
-    <logger name="org.springframework.security.oauth2" level="DEBUG" />
-    <logger name="org.mybatis" level="DEBUG" />
+            <logger name="org.bobj.common.crypto" level="DEBUG"/>
+            <logger name="org.bobj.user.service" level="DEBUG"/>
+            <logger name="org.springframework.security.oauth2" level="DEBUG"/>
+            <logger name="org.mybatis" level="DEBUG"/>
 
-      <AppenderRef ref="console"/>
-    </Logger>
-  </Loggers>
+            <AppenderRef ref="console"/>
+        </Logger>
+
+        <!-- Redis Connection get/close 로그 억제 -->
+        <Logger name="org.springframework.data.redis.core.RedisConnectionUtils" level="WARN" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="org.springframework.data.redis" level="INFO" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="io.lettuce.core.protocol" level="WARN" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="io.lettuce.core" level="WARN" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+    </Loggers>
 </Configuration>


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
기존 폴링 방식의 Redis 주문 체결 로직을 이벤트 기반(Pub/Sub)으로 전환하고, 주문 체결 처리를 트랜잭션 이후 이벤트로 비동기 처리하도록 리팩토링했습니다.

## 🔧 작업 내용
- OrderQueueConsumer를 MessageListener 기반 Pub/Sub 처리 방식으로 변경
- 주문 생성 시 트랜잭션 커밋 후 OrderPlacedEvent 발행하도록 수정
- OrderPlacedEventHandler에서 Redis 큐로 주문 ID 비동기 push
- 기존 스케줄러 폴링 방식 주석 처리


## ✅ 체크리스트
- 주문 생성 후 Redis 큐 정상 push 확인
-  주문 체결 정상 처리 확인
- 부분 체결, 완전 체결 시 로그 정상 출력 확인

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #305
