### PR TITLE
[FEAT] #294 Implement PortOne payment verification and webhook handling with idempotency

### DIFF
--- a/src/main/java/org/bobj/payment/domain/PaymentEventType.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentEventType.java
@@ -1,0 +1,17 @@
+package org.bobj.payment.domain;
+
+public enum PaymentEventType {
+    PAID, FAILED, CANCELED, PARTIAL_CANCEL;
+
+    public static PaymentEventType fromWebhook(String raw){
+        if(raw == null) return FAILED;
+        switch (raw.trim().toLowerCase()){
+            case "paid": return PAID;
+            case "cancelled":       // 포트원 스펠링 케이스
+            case "canceled":        return CANCELED; //  DB ENUM에 맞춤(한 L)
+            case "partial_cancel":  return PARTIAL_CANCEL;
+            default:                return FAILED;
+        }
+    }
+
+}

--- a/src/main/java/org/bobj/payment/domain/PaymentEventVO.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentEventVO.java
@@ -1,0 +1,22 @@
+package org.bobj.payment.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentEventVO {
+    private Long id;
+    private  String merchantUid; // 멱등키 구성요소
+    private String impUid;
+    private String eventType;
+    private LocalDateTime pgEventAt;
+    private String source;
+    private String payloadJson;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/bobj/payment/domain/PaymentStatus.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentStatus.java
@@ -5,5 +5,31 @@ public enum PaymentStatus {
     SUCCESS,
     FAILED,
     EXPIRED,
-    CANCELLED
+    CANCELLED;
+
+    /*
+    * PortOne Webhook 상태 문자열을 내부 상태로 매핑
+    * 안전을 위해 모르는 값은 FAILED 로 처리
+    *  */
+
+    public static PaymentStatus fromWebhook(String raw){
+        if(raw == null) return FAILED;
+        String s = raw.trim().toLowerCase();
+        switch (s) {
+            case "paid":            return SUCCESS;
+            case "partial_cancel":
+            case "cancelled":
+            case "canceled":        return CANCELLED;
+            case "failed":          return FAILED;
+            case "expired":         return EXPIRED;
+            case "ready":
+            case "pay_pending":     return PENDING;   // 일부 PG에서 대기 상태
+            default:                return FAILED;    // 알 수 없는 값은 보수적으로 실패 처리
+        }
+    }
+    /** 더 이상 바뀌지 않는 최종 상태 여부 */
+    public boolean isTerminal() {
+        return this == SUCCESS || this == FAILED || this == EXPIRED || this == CANCELLED;
+    }
+
 }

--- a/src/main/java/org/bobj/payment/domain/PaymentTransitions.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentTransitions.java
@@ -1,0 +1,28 @@
+package org.bobj.payment.domain;
+
+public final class PaymentTransitions {
+
+    private PaymentTransitions() {
+    }
+
+    /*
+     * 허용 전이 :
+     * PENDING -> SUCCESS / FAILED / EXPIRED
+     * SUCCESS -> CANCELLED
+     * 동일 상태 유지 허용
+     */
+    public static boolean allowed(PaymentStatus from, PaymentStatus to) {
+        if (from == null || from == to)
+            return true;
+        switch (from) {
+            case PENDING:
+                return to == PaymentStatus.SUCCESS
+                    || to == PaymentStatus.FAILED
+                    || to == PaymentStatus.EXPIRED;
+            case SUCCESS:
+                return to == PaymentStatus.CANCELLED;
+            default:
+                return false; // FAILED/EXPIRED/CANCELLED 에서 되돌리기 금지
+        }
+    }
+}

--- a/src/main/java/org/bobj/payment/domain/PaymentVO.java
+++ b/src/main/java/org/bobj/payment/domain/PaymentVO.java
@@ -9,11 +9,22 @@ import java.time.LocalDateTime;
 @Data
 @Builder
 public class PaymentVO {
+    private Long paymentId;          // 선택: mapper에서 keyProperty 사용 시
     private String impUid;
     private String merchantUid;
     private Long userId;
     private BigDecimal amount;
     private PaymentStatus status;
-    private LocalDateTime paidAt;
-//    private LocalDateTime createdAt;
+
+    private LocalDateTime paidAt;        // 승인 시각
+    private LocalDateTime canceledAt;    // 취소 시각
+    private String pgProvider;           // PG사 //장애/정산/통계에서 “어느 PG/채널의 문제인가?” 추적 가능.
+
+    private LocalDateTime lastEventAt;   // LWW 기준 시각
+    private String lastEventSource;      // VERIFY/WEBHOOK
+    private Long version;                // 낙관적 락
+
+    private LocalDateTime createdAt;     // 선택(조회용)
+    private LocalDateTime endAt;         // 선택(만료 관리)
 }
+

--- a/src/main/java/org/bobj/payment/dto/PortOnePaymentResponse.java
+++ b/src/main/java/org/bobj/payment/dto/PortOnePaymentResponse.java
@@ -12,7 +12,7 @@ public class PortOnePaymentResponse {
     private PaymentData response;
 
     @Data
-    public static class PaymentData{
+    public static class PaymentData {
         @JsonProperty("imp_uid")
         private String impUid;
 
@@ -20,7 +20,6 @@ public class PortOnePaymentResponse {
         private String merchantUid;
 
         private int amount;
-
         private String status;
 
         @JsonProperty("pay_method")
@@ -28,6 +27,11 @@ public class PortOnePaymentResponse {
 
         @JsonProperty("paid_at")
         private long paidAt;
+
+        //  취소 시각(없을 수 있으므로 Long 래퍼)
+        @JsonProperty("cancelled_at")     // 포트원은 대부분 이 키를 씀(두 L)
+        private Long cancelledAt;
+
 
     }
 

--- a/src/main/java/org/bobj/payment/dto/WebhookDto.java
+++ b/src/main/java/org/bobj/payment/dto/WebhookDto.java
@@ -1,0 +1,18 @@
+package org.bobj.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import lombok.Data;
+
+@Data
+public class WebhookDto {
+
+    @JsonProperty("imp_uid")
+    private String impUid;
+
+    @JsonProperty("merchant_uid")
+    private String merchantUid;
+
+    private String status;
+    private BigDecimal amount;
+}

--- a/src/main/java/org/bobj/payment/mapper/PaymentEventMapper.java
+++ b/src/main/java/org/bobj/payment/mapper/PaymentEventMapper.java
@@ -1,0 +1,19 @@
+package org.bobj.payment.mapper;
+
+import java.time.LocalDateTime;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.bobj.payment.domain.PaymentEventVO;
+
+@Mapper
+public interface PaymentEventMapper {
+
+
+        boolean existsByMerchantUidAndEventTypeAndPgEventAt(
+            @Param("merchantUid") String merchantUid,
+            @Param("eventType") String eventType,
+            @Param("pgEventAt") LocalDateTime pgEventAt);
+
+        void save(PaymentEventVO vo);
+}
+

--- a/src/main/java/org/bobj/payment/mapper/PaymentMapper.java
+++ b/src/main/java/org/bobj/payment/mapper/PaymentMapper.java
@@ -14,4 +14,6 @@ public interface PaymentMapper {
 
     PaymentVO findByImpUid(@Param("impUid") String impUid);
 
+    void update(PaymentVO vo);
+
 }

--- a/src/main/java/org/bobj/payment/repository/PaymentEventRepository.java
+++ b/src/main/java/org/bobj/payment/repository/PaymentEventRepository.java
@@ -1,0 +1,21 @@
+package org.bobj.payment.repository;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.bobj.payment.domain.PaymentEventVO;
+import org.bobj.payment.mapper.PaymentEventMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentEventRepository {
+    private final PaymentEventMapper mapper;
+
+    public boolean existsByMerchantUidAndEventTypeAndPgEventAt(String merchantUid, String eventType, LocalDateTime pgEventAt) {
+        return mapper.existsByMerchantUidAndEventTypeAndPgEventAt(merchantUid, eventType, pgEventAt);
+    }
+
+    public void save(PaymentEventVO vo) {
+        mapper.save(vo);
+    }
+}

--- a/src/main/java/org/bobj/payment/repository/PaymentRepository.java
+++ b/src/main/java/org/bobj/payment/repository/PaymentRepository.java
@@ -20,5 +20,7 @@ public class PaymentRepository {
     public PaymentVO findByImpUid(String impUid){
         return paymentMapper.findByImpUid(impUid);
     }
-
+    public void update(PaymentVO paymentVO){
+        paymentMapper.update(paymentVO);
+    }
 }

--- a/src/main/java/org/bobj/payment/service/PaymentService.java
+++ b/src/main/java/org/bobj/payment/service/PaymentService.java
@@ -1,22 +1,23 @@
 package org.bobj.payment.service;
 
-
-import static org.bobj.payment.domain.PaymentStatus.FAILED;
-
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.bobj.common.constants.ErrorCode;
 import org.bobj.payment.client.PortOneClient;
+import org.bobj.payment.domain.PaymentEventType;
+import org.bobj.payment.domain.PaymentEventVO;
 import org.bobj.payment.domain.PaymentStatus;
 import org.bobj.payment.domain.PaymentVO;
 import org.bobj.payment.dto.PortOnePaymentResponse;
 import org.bobj.payment.dto.PortOnePaymentResponse.PaymentData;
 import org.bobj.payment.dto.VerifyRequestDto;
+import org.bobj.payment.dto.WebhookDto;
 import org.bobj.payment.exception.PaymentException;
+import org.bobj.payment.repository.PaymentEventRepository;
 import org.bobj.payment.repository.PaymentRepository;
 import org.bobj.point.domain.PointChargeRequestVO;
 import org.bobj.point.service.PointChargeRequestService;
@@ -31,87 +32,238 @@ public class PaymentService {
 
     private final PortOneClient portOneClient;
     private final PaymentRepository paymentRepository;
-    private final PointService pointService; // 포인트 적립 처리용
+    private final PointService pointService;
     private final PointChargeRequestService pointChargeRequestService;
+    private final PaymentEventRepository paymentEventRepository;
 
+    public enum EventSource {VERIFY, WEBHOOK}
+
+    @Transactional
+    public void verifyWithPortOneAndApply(WebhookDto webhookDto, EventSource source) {
+        final String impUid = webhookDto.getImpUid();
+
+        PortOnePaymentResponse res = portOneClient.getPaymentInfo(impUid);
+        PaymentData pg = res.getResponse();
+        if (pg == null) {
+            throw new PaymentException(ErrorCode.PAYMENT_NOT_FOUND);
+        }
+
+        PointChargeRequestVO chargeReq =
+            pointChargeRequestService.findByMerchantUid(pg.getMerchantUid());
+        if (chargeReq == null) {
+            throw new PaymentException(ErrorCode.PAYMENT_REQUEST_NOT_FOUND);
+        }
+
+        final Long userId = chargeReq.getUserId();
+        applyEventFromPaymentData(userId, chargeReq, pg, source);
+    }
 
     @Transactional
     public void verifyPayment(Long userId, VerifyRequestDto requestDto) {
-        String impUid = requestDto.getImpUid();
-        BigDecimal requestAmount = requestDto.getAmount();
-        PaymentData paymentData = null;
+        final String impUid = requestDto.getImpUid();
 
-        try {
-            // 1. 포트원에서 결제 정보 조회
-            PortOnePaymentResponse response = portOneClient.getPaymentInfo(impUid);
-            paymentData = response.getResponse();
-
-            if (paymentData == null) {
-                throw new PaymentException(ErrorCode.PAYMENT_NOT_FOUND);
-            }
-
-            // 2. 요청 내역 조회 (merchant_uid 기준)
-            PointChargeRequestVO chargeRequest =
-                pointChargeRequestService.findByMerchantUid(paymentData.getMerchantUid());
-
-            if (chargeRequest == null) {
-                throw new PaymentException(ErrorCode.PAYMENT_REQUEST_NOT_FOUND);
-            }
-
-            // 3. 결제 금액 일치 확인
-            if (BigDecimal.valueOf(paymentData.getAmount()).compareTo(requestAmount) != 0) {
-                throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
-            }
-
-            // 4. 결제 상태 확인
-            if (!"paid".equalsIgnoreCase(paymentData.getStatus())) {
-                throw new PaymentException(ErrorCode.PAYMENT_NOT_COMPLETED);
-            }
-
-            // 5. 중복 결제 방지
-            if (paymentRepository.existsByImpUid(impUid)) {
-                throw new PaymentException(ErrorCode.PAYMENT_ALREADY_PROCESSED);
-            }
-
-            // 6. 상태 업데이트 & 포인트 지급
-            chargeRequest.setStatus("PAID");
-            chargeRequest.setImpUid(impUid);
-            pointChargeRequestService.updateStatusToPaid(chargeRequest);
-
-            pointService.chargePoint(userId, requestAmount, impUid);
-
-            // 7. 결제 정보 저장
-            paymentRepository.save(PaymentVO.builder()
-                .impUid(impUid)
-                .merchantUid(paymentData.getMerchantUid())
-                .userId(userId)
-                .amount(BigDecimal.valueOf(paymentData.getAmount()))
-                .status(PaymentStatus.SUCCESS)
-                .paidAt(Instant.ofEpochSecond(paymentData.getPaidAt())
-                    .atZone(ZoneId.systemDefault())
-                    .toLocalDateTime())
-                .build());
-
-        } catch (PaymentException e) {
-            // ❗검증 실패한 경우에도 로그 & 저장
-            log.error("[결제 실패] {} - {}", impUid, e.getErrorCode().name());
-
-            // 실패 정보도 저장 (중복 방지 필요)
-            if (!paymentRepository.existsByImpUid(impUid)) {
-                paymentRepository.save(PaymentVO.builder()
-                    .impUid(impUid)
-                    .merchantUid(paymentData != null ? paymentData.getMerchantUid() : null)
-                    .userId(userId)
-                    .amount(paymentData != null ? BigDecimal.valueOf(paymentData.getAmount()) : requestAmount)
-                    .status(FAILED)
-                    .paidAt(null)
-                    .build());
-            }
-
-            throw e; // 다시 던져서 ControllerAdvice에서 처리되도록
+        PortOnePaymentResponse response = portOneClient.getPaymentInfo(impUid);
+        PaymentData pg = response.getResponse();
+        if (pg == null) {
+            throw new PaymentException(ErrorCode.PAYMENT_NOT_FOUND);
         }
+
+        PointChargeRequestVO chargeReq =
+            pointChargeRequestService.findByMerchantUid(pg.getMerchantUid());
+        if (chargeReq == null) {
+            throw new PaymentException(ErrorCode.PAYMENT_REQUEST_NOT_FOUND);
+        }
+
+        if (userId == null) userId = chargeReq.getUserId();
+
+
+        if (requestDto.getAmount() != null &&
+            requestDto.getAmount().compareTo(BigDecimal.valueOf(pg.getAmount())) != 0) {
+            throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        applyEventFromPaymentData(userId, chargeReq, pg, EventSource.VERIFY);
     }
 
+    private void applyEventFromPaymentData(Long userId,
+        PointChargeRequestVO chargeReq,
+        PaymentData pg,
+        EventSource source) {
 
+        final String impUid = pg.getImpUid();
+        final String merchantUid = pg.getMerchantUid();
+        final BigDecimal paidAmt = BigDecimal.valueOf(pg.getAmount());
+        final String statusRaw = pg.getStatus();
+
+        final PaymentStatus next = PaymentStatus.fromWebhook(statusRaw);           // 내부 상태
+        final PaymentEventType evt = PaymentEventType.fromWebhook(statusRaw);      // 로그/멱등
+
+        final Long ts =
+            ("cancelled".equalsIgnoreCase(statusRaw) || "canceled".equalsIgnoreCase(statusRaw))
+                ? pg.getCancelledAt()
+                : pg.getPaidAt();
+        final LocalDateTime pgEventAt = (ts != null)
+            ? Instant.ofEpochSecond(ts).atZone(ZoneId.systemDefault()).toLocalDateTime()
+            : LocalDateTime.now();
+
+        // 1) 멱등 (payment_event 유니크)
+        if (paymentEventRepository.existsByMerchantUidAndEventTypeAndPgEventAt(
+            merchantUid, evt.name(), pgEventAt)) {
+            log.info("Duplicate event ignored: {} {} {}", merchantUid, evt.name(), pgEventAt);
+            return;
+        }
+
+        // 2) 현재 Payment
+        PaymentVO cur = paymentRepository.findByImpUid(impUid);
+
+        // 3) LWW: 기존 last_event_at보다 최신일 때만 갱신
+        if (cur != null && cur.getLastEventAt() != null && !pgEventAt.isAfter(
+            cur.getLastEventAt())) {
+            saveEventLog(merchantUid, impUid, evt.name(), pgEventAt, source, pg);
+            return;
+        }
+
+        // 4) 상태 전이 + 부수효과
+        switch (next) {
+            case SUCCESS: // paid
+                if (chargeReq.getAmount().compareTo(paidAmt) != 0) {
+                    saveEventLog(merchantUid, impUid, "FAILED_AMOUNT_MISMATCH", pgEventAt, source,
+                        pg);
+                    throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+                }
+
+                if (cur == null || cur.getStatus() != PaymentStatus.SUCCESS) {
+                    // 포인트 적립
+                    pointService.chargePoint(userId, paidAmt, impUid);
+
+                    // 원요청에 영수증/시각 박제
+                    chargeReq.setImpUid(impUid);
+                    chargeReq.setPaidAt(
+                        Instant.ofEpochSecond(pg.getPaidAt())
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime()
+                    );
+                    pointChargeRequestService.updateStatusToPaid(chargeReq);
+                }
+
+                if (cur == null) {
+                    cur = PaymentVO.builder()
+                        .impUid(impUid)
+                        .merchantUid(merchantUid)
+                        .userId(userId)
+                        .amount(paidAmt)
+                        .status(PaymentStatus.SUCCESS)
+                        .paidAt(Instant.ofEpochSecond(pg.getPaidAt())
+                            .atZone(ZoneId.systemDefault()).toLocalDateTime())
+                        .build();
+                } else {
+                    cur.setStatus(PaymentStatus.SUCCESS);
+                    cur.setAmount(paidAmt);
+                    cur.setPaidAt(Instant.ofEpochSecond(pg.getPaidAt())
+                        .atZone(ZoneId.systemDefault()).toLocalDateTime());
+                }
+
+                cur.setLastEventAt(pgEventAt);
+                cur.setLastEventSource(source.name());
+                cur.setVersion(cur.getVersion() == null ? 1 : cur.getVersion() + 1);
+
+                if (cur.getPaymentId() == null) {
+                    paymentRepository.save(cur);
+                } else {
+                    paymentRepository.update(cur);
+                }
+                break;
+
+            case CANCELLED:
+                // 부분취소는 스킵(나중에 처리)
+                if (evt == PaymentEventType.PARTIAL_CANCEL) {
+                    log.info(
+                        "Partial cancel received. Refund is not processed. merchantUid={}, impUid={}",
+                        merchantUid, impUid);
+                    saveEventLog(merchantUid, impUid, "PARTIAL_CANCEL_SKIPPED", pgEventAt, source,
+                        pg);
+                    break;
+                }
+
+                if (cur != null && cur.getStatus() == PaymentStatus.SUCCESS) {
+                    // 1) 포인트 회수
+                    pointService.requestRefund(userId, cur.getAmount());
+                    // 2) 원요청 취소로
+                    pointChargeRequestService.updateStatusToCancelled(chargeReq);
+                    // 3) payment 최신화
+                    cur.setStatus(PaymentStatus.CANCELLED);
+                    cur.setCanceledAt(pgEventAt);
+                    cur.setLastEventAt(pgEventAt);
+                    cur.setLastEventSource(source.name());
+                    cur.setVersion(cur.getVersion() == null ? 1 : cur.getVersion() + 1);
+                    paymentRepository.update(cur);
+                }
+                break;
+
+            case FAILED:
+            case EXPIRED:
+            default: // 기타는 실패로 처리
+                if (cur == null) {
+                    cur = PaymentVO.builder()
+                        .impUid(impUid)
+                        .merchantUid(merchantUid)
+                        .userId(userId)
+                        .amount(paidAmt)
+                        .status(PaymentStatus.FAILED)
+                        .build();
+                    cur.setLastEventAt(pgEventAt);
+                    cur.setLastEventSource(source.name());
+                    cur.setVersion(1L);
+                    paymentRepository.save(cur);
+                } else {
+                    cur.setStatus(PaymentStatus.FAILED);
+                    cur.setLastEventAt(pgEventAt);
+                    cur.setLastEventSource(source.name());
+                    cur.setVersion(cur.getVersion() == null ? 1 : cur.getVersion() + 1);
+                    paymentRepository.update(cur);
+                }
+                break;
+        }
+
+// 5) 이벤트 로그 (멱등 키)
+        saveEventLog(merchantUid, impUid, evt.name(), pgEventAt, source, pg);
+
+    }
+
+    // PaymentService
+    private void saveEventLog(
+        String merchantUid,
+        String impUid,
+        String eventType,
+        LocalDateTime pgEventAt,
+        EventSource source,
+        org.bobj.payment.dto.PortOnePaymentResponse.PaymentData pg
+    ) {
+        try {
+            String payload = null;
+            try {
+                // ObjectMapper 주입 안 했으면 일단 주석/삭제해도 됨 (JSON 저장 생략)
+                // payload = objectMapper.writeValueAsString(pg);
+            } catch (Exception ignore) {
+            }
+
+            log.info("event-log try: merchantUid={}, impUid={}, type={}, at={}, source={}",
+                merchantUid, impUid, eventType, pgEventAt, source);
+
+            paymentEventRepository.save(
+                PaymentEventVO.builder()
+                    .merchantUid(merchantUid)
+                    .impUid(impUid)
+                    .eventType(eventType)     // 예: "PAID" | "CANCELED" | "PARTIAL_CANCEL_SKIPPED"
+                    .pgEventAt(pgEventAt)
+                    .source(source.name())    // "VERIFY" | "WEBHOOK"
+                    .payloadJson(payload)     // JSON 넣으려면 위에서 직렬화
+                    .build()
+            );
+        } catch (Exception e) {
+            log.debug("event log save skipped: {}", e.getMessage());
+            log.error("event log save failed", e); // ← 스택트레이스 보이게
+        }
+    }
 
 }

--- a/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
+++ b/src/main/java/org/bobj/point/controller/PointChargeRequestController.java
@@ -76,12 +76,14 @@ public class PointChargeRequestController {
         @RequestBody @ApiParam(value = "결제 검증 요청 DTO", required = true) VerifyRequestDto requestDto,
         @ApiIgnore @AuthenticationPrincipal UserPrincipal principal // ★ 변경
     ) {
-        if (principal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body((ApiCommonResponse<String>) ApiCommonResponse.createError("인증이 필요합니다."));
-        }
+//        if (principal == null) {
+//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+//                .body((ApiCommonResponse<String>) ApiCommonResponse.createError("인증이 필요합니다."));
+//        }
 
-        Long userId = principal.getUserId(); // ★ 변경
+
+        Long userId = (principal != null) ? principal.getUserId() : null; // 💡 principal 없어도 통과
+        paymentService.verifyPayment(userId, requestDto);
         log.info("결제 검증 요청: userId={}, impUid={}", userId, requestDto.getImpUid());
 
         paymentService.verifyPayment(userId, requestDto);

--- a/src/main/java/org/bobj/point/mapper/PointChargeRequestMapper.java
+++ b/src/main/java/org/bobj/point/mapper/PointChargeRequestMapper.java
@@ -9,5 +9,12 @@ public interface PointChargeRequestMapper {
 
     PointChargeRequestVO findByMerchantUid(@Param("merchantUid") String merchantUid);
 
+    //성공 전이(고정): PAID + imp_uid + paid_at
     void updateStatusAndImpUid(PointChargeRequestVO request);
+
+    //취소 전이(고정): CANCELLED
+    void updateStatusToCancelled(@Param("merchantUid") String merchantUid);
+
+
+
 }

--- a/src/main/java/org/bobj/point/repository/PointChargeRequestRepository.java
+++ b/src/main/java/org/bobj/point/repository/PointChargeRequestRepository.java
@@ -22,4 +22,9 @@ public class PointChargeRequestRepository {
         mapper.updateStatusAndImpUid(request);
     }
 
+    //취소 전이
+    public void updateStatusToCancelled(String merchantUid) {
+        mapper.updateStatusToCancelled(merchantUid);
+    }
+
 }

--- a/src/main/java/org/bobj/point/service/PointChargeRequestService.java
+++ b/src/main/java/org/bobj/point/service/PointChargeRequestService.java
@@ -38,6 +38,12 @@ public class PointChargeRequestService {
 
     // 필요 시 FAILED 상태 처리도 추가 가능
 
+    @Transactional
+    public void updateStatusToCancelled(PointChargeRequestVO req) {
+        // 필요하면 req.setStatus("CANCELLED"); req.setImpUid(null); 등 사전 세팅
+        pointChargeRequestRepository.updateStatusToCancelled(req.getMerchantUid());
+    }
+
 
 
 

--- a/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/bobj/user/security/JwtAuthenticationFilter.java
@@ -93,6 +93,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
 
         String path = request.getRequestURI();
+        if (path.startsWith("/api/point/webhook")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String method = request.getMethod();
         log.debug("JWT Filter 처리: {} {}", method, path);
 
@@ -103,7 +108,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/webjars/") ||
                 path.contains("swagger") ||
-                path.endsWith("favicon.ico")) {
+                path.endsWith("favicon.ico") ||
+                path.startsWith("/api/point/webhook") )   // ✅ PortOne 웹훅)
+         {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/resources/org/bobj/payment/mapper/PaymentEventMapper.xml
+++ b/src/main/resources/org/bobj/payment/mapper/PaymentEventMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.bobj.payment.mapper.PaymentEventMapper">
+
+  <resultMap id="PaymentEventResultMap" type="org.bobj.payment.domain.PaymentEventVO">
+    <id     property="id"           column="id"/>
+    <result property="merchantUid"  column="merchant_uid"/>
+    <result property="impUid"       column="imp_uid"/>
+    <result property="eventType"    column="event_type"/>
+    <result property="pgEventAt"    column="pg_event_at"/>
+    <result property="source"       column="source"/>
+    <result property="payloadJson"  column="payload_json"/>
+    <result property="createdAt"    column="created_at"/>
+  </resultMap>
+
+  <select id="existsByMerchantUidAndEventTypeAndPgEventAt" resultType="boolean">
+    SELECT EXISTS(
+      SELECT 1
+      FROM payment_event
+      WHERE merchant_uid = #{merchantUid}
+        AND event_type   = #{eventType}
+        AND pg_event_at  = #{pgEventAt}
+    )
+  </select>
+
+  <insert id="save" parameterType="org.bobj.payment.domain.PaymentEventVO"
+    useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO payment_event
+    (merchant_uid, imp_uid, event_type, pg_event_at, source, payload_json)
+    VALUES
+      (#{merchantUid}, #{impUid}, #{eventType},
+       #{pgEventAt, jdbcType=TIMESTAMP}, #{source}, #{payloadJson})
+  </insert>
+
+
+</mapper>

--- a/src/main/resources/org/bobj/payment/mapper/PaymentMapper.xml
+++ b/src/main/resources/org/bobj/payment/mapper/PaymentMapper.xml
@@ -1,38 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE mapper
-  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.bobj.payment.mapper.PaymentMapper">
 
-
   <resultMap id="PaymentResultMap" type="org.bobj.payment.domain.PaymentVO">
-    <result property="impUid" column="imp_uid"/>
-    <result property="merchantUid" column="merchant_uid"/>
-    <result property="userId" column="user_id"/>
-    <result property="amount" column="amount"/>
-    <result property="status" column="status" javaType="org.bobj.payment.domain.PaymentStatus"/>
-    <result property="paidAt" column="paid_at"/>
+    <id     column="payment_id"       property="paymentId"/>
+    <result column="imp_uid"          property="impUid"/>
+    <result column="merchant_uid"     property="merchantUid"/>
+    <result column="user_id"          property="userId"/>
+    <result column="amount"           property="amount"/>
+    <result column="status"           property="status"/> <!-- enum 문자열 매핑 -->
+    <result column="paid_at"          property="paidAt"/>
+    <result column="canceled_at"      property="canceledAt"/>
+    <result column="pg_provider"      property="pgProvider"/>
+    <result column="last_event_at"    property="lastEventAt"/>
+    <result column="last_event_source" property="lastEventSource"/>
+    <result column="version"          property="version"/>
+    <result column="created_at"       property="createdAt"/>
+    <result column="end_at"           property="endAt"/>
   </resultMap>
 
-  <!-- imp_uid 존재 여부 확인 -->
-  <select id="existsByImpUid" resultType="boolean">
-    SELECT EXISTS(
-    SELECT 1
-    FROM payment
-    WHERE imp_uid = #{impUid}
-    )
+  <select id="existsByImpUid" parameterType="string" resultType="boolean">
+    SELECT EXISTS(SELECT 1 FROM payment WHERE imp_uid = #{impUid})
   </select>
 
-  <insert id="save">
-    INSERT INTO payment (imp_uid, merchant_uid, user_id, amount, status, paid_at)
-    VALUES (#{impUid}, #{merchantUid}, #{userId}, #{amount}, #{status}, #{paidAt})
-  </insert>
-
-  <!-- ✅ resultMap 적용 -->
-  <select id="findByImpUid" resultMap="PaymentResultMap">
+  <select id="findByImpUid" parameterType="string" resultMap="PaymentResultMap">
     SELECT *
     FROM payment
     WHERE imp_uid = #{impUid}
+      LIMIT 1
   </select>
+
+  <insert id="save" parameterType="org.bobj.payment.domain.PaymentVO"
+    useGeneratedKeys="true" keyProperty="paymentId">
+    INSERT INTO payment
+    (imp_uid, merchant_uid, user_id, amount, status, paid_at, canceled_at,
+     pg_provider, last_event_at, last_event_source, version)
+    VALUES
+      (#{impUid}, #{merchantUid}, #{userId}, #{amount}, #{status}, #{paidAt}, #{canceledAt},
+       #{pgProvider}, #{lastEventAt}, #{lastEventSource}, #{version})
+  </insert>
+
+  <update id="update" parameterType="org.bobj.payment.domain.PaymentVO">
+    UPDATE payment
+    SET merchant_uid      = #{merchantUid},
+        user_id           = #{userId},
+        amount            = #{amount},
+        status            = #{status},
+        paid_at           = #{paidAt},
+        canceled_at       = #{canceledAt},
+        pg_provider       = #{pgProvider},
+        last_event_at     = #{lastEventAt},
+        last_event_source = #{lastEventSource},
+        version           = #{version}
+    WHERE imp_uid = #{impUid}
+  </update>
 
 </mapper>

--- a/src/main/resources/org/bobj/point/mapper/PointChargeRequestMapper.xml
+++ b/src/main/resources/org/bobj/point/mapper/PointChargeRequestMapper.xml
@@ -22,17 +22,38 @@
   </insert>
 
 
-  <select id="findByMerchantUid" parameterType="String" resultType="PointChargeRequestVO">
-    SELECT *
+  <select id="findByMerchantUid" parameterType="string"
+    resultType="org.bobj.point.domain.PointChargeRequestVO">
+    SELECT
+      id,
+      user_id     AS userId,
+      amount,
+      merchant_uid AS merchantUid,
+      imp_uid     AS impUid,
+      status,
+      created_at  AS createdAt,
+      paid_at     AS paidAt
     FROM point_charge_request
-    where merchant_uid = #{merchantUid}
+    WHERE merchant_uid = #{merchantUid}
+      LIMIT 1
   </select>
 
-  <update id="updateStatusAndImpUid" parameterType="PointChargeRequestVO">
+
+  <update id="updateStatusAndImpUid"
+    parameterType="org.bobj.point.domain.PointChargeRequestVO">
     UPDATE point_charge_request
-    SET status = #{status},
-      imp_uid = #{impUid},
-      paid_at = NOW()
+    SET status  = 'PAID',
+        imp_uid = #{impUid},
+        paid_at = #{paidAt, jdbcType=TIMESTAMP}
+    WHERE merchant_uid = #{merchantUid}
+  </update>
+
+
+
+  <!--  취소 상태로 변경 -->
+  <update id="updateStatusToCancelled" parameterType="string">
+    UPDATE point_charge_request
+    SET status = 'CANCELLED'
     WHERE merchant_uid = #{merchantUid}
   </update>
 

--- a/src/main/webapp/test-payment.html
+++ b/src/main/webapp/test-payment.html
@@ -16,7 +16,7 @@
 
   function requestPay() {
 
-    const merchant_uid = "point_20250804001510_1_fba1d505"; // DB와 일치
+    const merchant_uid = "point_20258775646754_1_6d34043f"; // DB와 일치
 
     IMP.request_pay({
       pg: "kakaopay.TC0ONETIME",
@@ -32,7 +32,7 @@
     }, function (rsp) {
       if (rsp.success) {
         alert("결제 성공! 서버에 결제 정보 전송 중...");
-        axios.post("http://localhost:8080/api/point/verify", {
+        axios.post("http://localhost:8080/api/auth/point/verify", {
           impUid: rsp.imp_uid,
           amount: 5000
         }, {


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
PortOne 결제 검증(verify) 및 웹훅(webhook) 기반의 멱등/최신 이벤트 처리 로직을 구현하고, 결제·포인트 적립 관련 모듈 구조를 리팩토링했습니다.

## 🔧 작업 내용
- `PaymentService`에 PG 단건 조회 기반 결제 검증 로직 구현
- `payment_event` 테이블 연동 및 멱등성 키 적용(merchant_uid, event_type, pg_event_at)
- verify / webhook 동시 수신 시 최신 이벤트만 반영하도록 로직 추가
- `PaymentMapper`, `PaymentEventMapper` 및 XML 쿼리 파일 추가
- `PointChargeRequestController`에서 결제 검증 API(`/api/auth/point/verify`) 연동
- FK 제약 기반 포인트 적립 로직 수정 및 유저 존재 여부 체크 강화
- DTO(`WebhookDto`, `PortOnePaymentResponse`) 정의 및 서비스 로직 적용
- 테스트용 결제 페이지(`test-payment.html`) 추가

## ✅ 체크리스트
- 결제 승인 시 verify 호출 후 payment_event insert 정상 동작
- 웹훅 수신 시 최신 이벤트 반영 여부 확인
- 금액 불일치, 상태 불일치 시 처리 로그 및 예외 응답 확인
- FK 제약 위반 없이 포인트 적립 정상 처리
- 테스트 페이지를 통한 수동 결제 검증 성공

## 📝 기타 참고 사항
- `recon_result`는 추후 D+1 리컨실 배치 구현 시 데이터 적재 예정
- 부분취소 이벤트(`PARTIAL_CANCEL`) 처리 로직은 차후 구현 예정

## 📎 관련 이슈
Close #310
