### PR TITLE
[FEAT] Log point transactions on trade settlement (INVEST/TRADE_SALE)…

### DIFF
--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -8,6 +8,7 @@ import org.bobj.order.domain.OrderVO;
 import org.bobj.order.domain.OrderType;
 import org.bobj.order.mapper.OrderMapper;
 import org.bobj.orderbook.service.OrderBookService;
+import org.bobj.point.domain.PointTransactionType;
 import org.bobj.point.domain.PointVO;
 import org.bobj.point.service.PointService;
 import org.bobj.share.domain.ShareVO;
@@ -210,6 +211,7 @@ public class OrderMatchingService {
             // SHARES 테이블 업데이트
             shareMapper.update(existingShare.getShareId(), newShareCount, newAverageAmount);
         }
+        pointService.appendTransactionByUserId(userId, PointTransactionType.INVEST, totalTradeCost);
     }
 
     // 매도자 포인트 업데이트
@@ -241,6 +243,7 @@ public class OrderMatchingService {
             // 일부 주식을 매도한 경우: 수량만 감소 (평균 단가는 매도 시 변하지 않음)
             shareMapper.update(existingShare.getShareId(), newShareCount, existingShare.getAverageAmount());
         }
+        pointService.appendTransactionByUserId(userId, PointTransactionType.TRADE_SALE, totalTradeRevenue);
     }
 
 }

--- a/src/main/java/org/bobj/point/service/PointService.java
+++ b/src/main/java/org/bobj/point/service/PointService.java
@@ -269,4 +269,27 @@ public class PointService {
 
         pointTransactionRepository.insert(tx);
     }
+
+
+    @Transactional
+    public void appendTransactionByUserId(Long userId, PointTransactionType type, BigDecimal amount) {
+        // point_id 확보를 위해 for update로 조회 (없으면 0원 생성)
+        PointVO point = pointRepository.findByUserIdForUpdate(userId);
+        if (point == null) {
+            point = PointVO.builder().userId(userId).amount(BigDecimal.ZERO).build();
+            pointRepository.insert(point);
+            point = pointRepository.findByUserIdForUpdate(userId); // point_id 확보용 재조회
+        }
+
+        PointTransactionVO tx = PointTransactionVO.builder()
+            .pointId(point.getPointId())
+            .type(type)            // ENUM 그대로 저장
+            .amount(amount)        // 금액은 '양수'로, 방향은 type으로 해석
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        pointTransactionRepository.insert(tx);
+    }
+
+
 }


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
주문 **체결 시 포인트 로그가 누락되고, 잔고가 이중 반영될 수 있는 위험**을 해소했습니다.  
잔고 갱신 이후 **point_transaction(INVEST/TRADE_SALE)** 를 **동일 트랜잭션 내**에서 기록하도록 보완했습니다.

## 🔧 작업 내용
- `OrderMatchingService`
  - `processBuyTradeAssets()` / `processSellTradeAssets()`에서 **잔고 갱신 후**  
    `pointService.appendTransactionByUserId(userId, type, amount)` 호출 추가
  - 매수자 → `INVEST`(지출), 매도자 → `TRADE_SALE`(수입)로 로그 기록
- `PointService`
  - `appendTransactionByUserId(Long userId, PointTransactionType type, BigDecimal amount)` **신규**  
    - `findByUserIdForUpdate`로 **point 행 보장**(없으면 0원 생성)  
    - **잔고 변경 없이 트랜잭션 로그만** insert
- 정밀도/코드 품질
  - `new BigDecimal(int)` → `BigDecimal.valueOf(int)`로 교체
  - `BigDecimal.ROUND_HALF_UP`(deprecated) → `RoundingMode.HALF_UP` 적용
- 락/정합성
  - `points`/`shares` 조회에 **FOR UPDATE** 경로 사용 확인

> 참고: 코드 전반에서 사용 중인 `PointTransactionType`과 DDL ENUM 불일치 시  
> `WITHDRAW/REFUND/CANCEL` 추가가 **선행/동시 적용**되어야 합니다.

## ✅ 체크리스트
- [ ] 체결 1건 시 `point_transaction`에 **INVEST(매수자)**, **TRADE_SALE(매도자)** 각 1건 기록
- [ ] 부분 체결(2회 이상) 시 로그가 **회차별 누적**되며 합계가 최종 체결 금액과 일치
- [ ] **잔고 이중 반영 없음**(로그 기록 메서드는 잔고 변경 금지)
- [ ] `points` FK 위반 없음(미존재 시 0원 생성 로직 동작)
- [ ] 동시성 하에서 에러 발생 시 **원자적 롤백** 확인

## 📝 기타 참고 사항
- 추후 회계/정산 단순화를 위해 `point_transaction.amount`에 **부호 저장**(옵션 B)로 전환 시  
  마이그레이션 설계가 필요합니다. 현재는 **양수 저장 + type로 방향 해석**(옵션 A)을 유지합니다.
- 리포트/정산/리컨실 배치와의 연계는 별도 이슈에서 진행 예정입니다.

## 📎 관련 이슈
Close #322 
