### PR TITLE
[FIX] 알림 API 엔드포인트 RESTful하게 수정

### DIFF
--- a/src/main/java/org/bobj/notification/controller/NotificationController.java
+++ b/src/main/java/org/bobj/notification/controller/NotificationController.java
@@ -47,7 +47,7 @@ public class NotificationController {
         return ResponseEntity.ok(ApiCommonResponse.createSuccess(notifications));
     }
 
-    @PutMapping("/{notificationId}/read")
+    @PatchMapping("/{notificationId}")
     @ApiOperation(value = "특정 알림 읽음 처리", notes = "특정 알림을 '읽음' 상태로 변경합니다.")
     @ApiImplicitParam(name = "notificationId", value = "읽음 처리할 알림 ID", required = true, dataType = "long", paramType = "path")
     @ApiResponses(value = {
@@ -65,7 +65,7 @@ public class NotificationController {
         return ResponseEntity.ok(ApiCommonResponse.createSuccess("알림이 읽음 처리되었습니다."));
     }
 
-    @PutMapping("/read-all")
+    @PatchMapping("/read-all")
     @ApiOperation(value = "모든 알림 읽음 처리", notes = "현재 로그인된 사용자의 모든 읽지 않은 알림을 '읽음' 상태로 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "모든 알림 읽음 처리 성공", response = ApiCommonResponse.class),


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
알림 API 엔드포인트를 RESTful하게 수정하는 리팩토링 작업입니다. 기존에 PUT으로 구현된 알림 읽음 처리 로직을 **PATCH**로 변경하고, URI에서 불필요한 동사를 제거하여 API의 일관성을 높였습니다.

## 🔧 작업 내용

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #328
