### PR TITLE
[FIX] #332 Modify Funding Mapper

### DIFF
--- a/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
+++ b/src/main/resources/org/bobj/funding/mapper/FundingMapper.xml
@@ -197,7 +197,7 @@
     SELECT f.funding_id, p.title
     FROM fundings f
            JOIN properties p ON f.property_id = p.property_id
-    WHERE f.status = 'ENDED'
+    WHERE f.status = 'ENDED' AND p.status = 'APPROVED'
     ORDER BY f.funding_end_date DESC
     LIMIT #{limit} OFFSET #{offset}
   </select>


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
거래 리스트 조회 API에서 펀딩 완료만 불러와야하는데 매각 완료로 같이 불러오는 이슈

## 🔧 작업 내용
펀딩 상태가 ended이면서 매물 상태가 approved인 펀딩 데이터만 불러오도록 쿼리문 수정

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항

## 📎 관련 이슈
Close #332 
