### PR TITLE
[REFACTOR] 호가창 실시간 업데이트 레디스 캐시 도입

### DIFF
--- a/src/main/java/org/bobj/config/RedisConfig.java
+++ b/src/main/java/org/bobj/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package org.bobj.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.bobj.order.consumer.OrderQueueConsumer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -50,8 +53,6 @@ public class RedisConfig {
         // redis 연결 정보(host, port, password)
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(
                 host, port);
-//        redisStandaloneConfiguration.setPassword(password);
-
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
@@ -65,7 +66,21 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper());
+        template.setValueSerializer(jsonRedisSerializer);
+        template.setHashValueSerializer(jsonRedisSerializer);
+
+        template.afterPropertiesSet();
+
         return template;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        return objectMapper;
     }
 
     @Bean

--- a/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
+++ b/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
@@ -2,10 +2,10 @@ package org.bobj.order.consumer;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.order.domain.OrderVO;
 import org.bobj.order.mapper.OrderMapper;
 import org.bobj.order.service.OrderMatchingService;
+import org.bobj.orderbook.service.OrderBookService;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,6 +19,7 @@ public class OrderQueueConsumer  implements MessageListener {
     private final RedisTemplate<String, Object> redisTemplate;
     private final OrderMapper orderMapper;
     private final OrderMatchingService orderMatchingService;
+    private final OrderBookService orderBookService;
 
     // Pub/Sub 메시지를 처리하는 메서드
     @Override
@@ -92,6 +93,8 @@ public class OrderQueueConsumer  implements MessageListener {
                 break;
             }
         }
+        // 큐 처리가 모두 끝난 후, 캐시를 무효화합니다.
+        orderBookService.evictOrderBookCache(fundingId);
     }
 
  //매 10초마다 Redis 큐에서 주문 ID 꺼내서 처리

--- a/src/main/java/org/bobj/order/controller/OrderController.java
+++ b/src/main/java/org/bobj/order/controller/OrderController.java
@@ -110,7 +110,10 @@ public class OrderController {
 
         ApiCommonResponse<OrderResponseDTO> response = ApiCommonResponse.createSuccess(created);
 
-        //소켓 메세지 pub
+        // 1. 주문 완료 후, 해당 펀딩 ID의 캐시 삭제
+        orderBookService.evictOrderBookCache(created.getFundingId());
+
+        // 2. 소켓 메세지 pub
         publishOrderBookUpdate(created.getFundingId());
 
         return ResponseEntity.ok(response);
@@ -152,6 +155,9 @@ public class OrderController {
     })
     public ResponseEntity<ApiCommonResponse<String>> cancelOrder(@PathVariable Long orderId) {
         Long fundingId = service.cancelOrder(orderId);
+
+        // 1. 주문 취소 후, 해당 펀딩 ID의 캐시를 먼저 삭제
+        orderBookService.evictOrderBookCache(fundingId);
 
         //소켓 메세지 pub
         publishOrderBookUpdate(fundingId);

--- a/src/main/java/org/bobj/order/service/OrderMatchingService.java
+++ b/src/main/java/org/bobj/order/service/OrderMatchingService.java
@@ -31,12 +31,10 @@ public class OrderMatchingService {
     private final OrderMapper orderMapper;
     private final TradeMapper tradeMapper;
     private final ShareMapper shareMapper;
-    private final PointService pointService;
 
-    private final OrderBookService orderBookService;
+    private final PointService pointService;
     private final FundingService fundingService;
     private final NotificationService notificationService;
-
 
     @Transactional
     public int processOrderMatching(OrderVO newOrder) {

--- a/src/main/java/org/bobj/orderbook/service/OrderBookService.java
+++ b/src/main/java/org/bobj/orderbook/service/OrderBookService.java
@@ -4,4 +4,6 @@ import org.bobj.orderbook.dto.response.OrderBookResponseDTO;
 
 public interface OrderBookService {
     OrderBookResponseDTO getOrderBookByFundingId(Long fundingId);
+    void evictOrderBookCache(Long fundingId);
 }
+


### PR DESCRIPTION
---
name: ✨ PR 템플릿
about: 새로운 기능 구현 및 추가를 위한 PR 템플릿입니다.
---
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
호가창(Order Book) 실시간 업데이트 시 발생하는 데이터베이스(DB) 부하를 개선하기 위해, Redis 캐시를 도입하는 리팩토링 작업을 진행했습니다.

주문 발생, 체결, 취소 등의 이벤트가 있을 때만 캐시를 무효화하고, 그 외의 조회 요청은 초고속의 메모리 기반 캐시를 사용함으로써 시스템의 전반적인 응답 속도와 안정성을 높였습니다.

## 🔧 작업 내용
<전체적인 흐름>
 1. 주문/취소 발생 시: OrderController가 DB에 주문을 저장/삭제한 후, Redis에 저장된 해당 펀딩 ID의 호가창 캐시를 즉시 삭제합니다.

 2. 웹소켓 발행 시: OrderBookService를 호출하여 호가창 정보를 가져오려 할 때, 캐시가 존재하지 않으므로 DB에서 최신 데이터를 다시 계산합니다.

 3. 호가창 재계산 후: 계산된 최신 호가창 정보를 Redis 캐시에 저장하고, 웹소켓을 통해 클라이언트에게 발행합니다.

 4. 다음 조회 시: 캐시가 유효한 동안에는 OrderBookService가 DB에 접근하지 않고, Redis에서 데이터를 직접 가져와 빠르게 응답합니다.

 5. 비동기 주문 체결 시: OrderQueueConsumer가 큐에 쌓인 주문 처리를 모두 완료한 후, DB의 최종 상태를 반영하기 위해 호가창 캐시를 다시 삭제합니다.


<기존 방식과 차이>
가장 큰 차이는 **호가창을 조회하는 행위**가 얼마나 자주 발생하는지에 있습니다.

1. **클라이언트의 '보기' 요청:** 수많은 사용자가 호가창을 실시간으로 보고 있습니다. 이들은 새로운 주문을 넣지 않아도 계속해서 데이터를 요청(또는 WebSocket을 통해 받기)합니다.
2. **주문 변동 (새로운 주문/취소):** 이 행위는 '보기' 요청보다 훨씬 적게 발생합니다.

기존 방식은 '보기' 요청이 들어올 때마다, 심지어 아무런 변화가 없더라도, 매번 느린 DB 쿼리를 실행합니다. 이는 엄청난 부하를 유발합니다.

Redis 캐시를 도입하면, 주문 변동이 있을 때만 딱 한 번 DB에 접근해서 최신 호가창을 계산하고, 그 이후의 수많은 '보기' 요청은 모두 초고속의 **Redis 메모리**에서 처리됩니다.

따라서, "변동이 있을 때 재계산"하는 것은 동일하더라도, **계산의 빈도와 속도**가 완전히 달라집니다.

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주문 변동 시 매번 호가창 전체를 재계산하는 것은 기존과 동일하지만, 이 계산 작업이 DB가 아닌 메모리(Redis)에서 이루어지므로, 사용자가 느끼는 체감 속도는 크게 향상됩니다.

## 📎 관련 이슈
Close #347
