### PR TITLE
[REFACTOR] 호가창 업데이트 방법 보완

### DIFF
--- a/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
+++ b/src/main/java/org/bobj/order/consumer/OrderQueueConsumer.java
@@ -93,8 +93,8 @@ public class OrderQueueConsumer  implements MessageListener {
                 break;
             }
         }
-        // 큐 처리가 모두 끝난 후, 캐시를 무효화합니다.
-        orderBookService.evictOrderBookCache(fundingId);
+
+        orderBookService.updateOrderBookAndSendUpdates(fundingId);
     }
 
  //매 10초마다 Redis 큐에서 주문 ID 꺼내서 처리

--- a/src/main/java/org/bobj/orderbook/dto/response/OrderBookUpdateDTO.java
+++ b/src/main/java/org/bobj/orderbook/dto/response/OrderBookUpdateDTO.java
@@ -1,0 +1,49 @@
+package org.bobj.orderbook.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.bobj.orderbook.dto.OrderBookEntryDTO;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class OrderBookUpdateDTO {
+    /**
+     * 업데이트 유형을 정의하는 열거형 (Enum).
+     * <p>
+     * - FULL: 전체 호가창 업데이트
+     * - ADD: 새로운 호가 가격 추가
+     * - UPDATE: 기존 호가 수량 변경
+     * - REMOVE: 호가 가격 삭제 (수량 0)
+     * - PRICE_UPDATE: 현재가만 변경
+     */
+    public enum Type {
+        FULL, ADD, UPDATE, REMOVE, PRICE_UPDATE
+    }
+    // 변경 유형
+    private Type type;
+
+    // 변경된 호가의 가격
+    private BigDecimal price;
+
+    // 변경된 수량
+    private BigDecimal quantity;
+
+    // 이 업데이트가 매수(BUY)인지 매도(SELL)인지 구분
+    private String orderType;
+
+    // 변경이 발생한 시점의 타임스탬프
+    private LocalDateTime timestamp;
+
+    // 전체 호가창 업데이트 시 사용 (FULL 타입)
+    private List<OrderBookEntryDTO> buyOrders;
+    private List<OrderBookEntryDTO> sellOrders;
+
+    // 가격 정보 업데이트 시 사용 (PRICE_UPDATE 타입)
+    private BigDecimal currentPrice;
+    private BigDecimal upperLimitPrice;
+    private BigDecimal lowerLimitPrice;
+}

--- a/src/main/java/org/bobj/orderbook/service/OrderBookService.java
+++ b/src/main/java/org/bobj/orderbook/service/OrderBookService.java
@@ -1,9 +1,12 @@
 package org.bobj.orderbook.service;
 
 import org.bobj.orderbook.dto.response.OrderBookResponseDTO;
+import org.bobj.orderbook.dto.response.OrderBookUpdateDTO;
+
+import java.util.List;
 
 public interface OrderBookService {
     OrderBookResponseDTO getOrderBookByFundingId(Long fundingId);
-    void evictOrderBookCache(Long fundingId);
+    List<OrderBookUpdateDTO> updateOrderBookAndSendUpdates(Long fundingId);
 }
 

--- a/src/main/java/org/bobj/orderbook/service/OrderBookServiceImpl.java
+++ b/src/main/java/org/bobj/orderbook/service/OrderBookServiceImpl.java
@@ -2,8 +2,6 @@ package org.bobj.orderbook.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.bobj.common.ActiveSubscriptionsChecker;
-import org.bobj.funding.domain.FundingVO;
 import org.bobj.funding.dto.FundingDetailResponseDTO;
 import org.bobj.funding.mapper.FundingMapper;
 import org.bobj.order.domain.OrderType;
@@ -11,21 +9,16 @@ import org.bobj.order.domain.OrderVO;
 import org.bobj.order.mapper.OrderMapper;
 import org.bobj.orderbook.dto.OrderBookEntryDTO;
 import org.bobj.orderbook.dto.response.OrderBookResponseDTO;
-import org.bobj.property.domain.PropertyVO;
-import org.bobj.property.mapper.PropertyMapper;
-import org.bobj.trade.domain.TradeVO;
+import org.bobj.orderbook.dto.response.OrderBookUpdateDTO;
 import org.bobj.trade.mapper.TradeMapper;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -46,17 +39,103 @@ public class OrderBookServiceImpl implements OrderBookService{
     @Transactional(readOnly = true)
     @Override
     public OrderBookResponseDTO getOrderBookByFundingId(Long fundingId) {
-
         String cacheKey = "orderBook:" + fundingId;
-
-        // 1.Redis 캐시에서 데이터 조회
         OrderBookResponseDTO cachedOrderBook = orderBookRedisTemplate.opsForValue().get(cacheKey);
+
         if (cachedOrderBook != null) {
             return cachedOrderBook;
         }
 
+        // 캐시 미스 시, 호가창을 계산하고 캐시에 저장
+        return calculateAndCacheOrderBook(fundingId);
+    }
 
-        // 2. 캐시 미스 시, 기존 로직으로 호가창 계산
+    @Transactional
+    @Override
+    public List<OrderBookUpdateDTO> updateOrderBookAndSendUpdates(Long fundingId) {
+        String cacheKey = "orderBook:" + fundingId;
+
+        // 1. Redis에서 이전 호가창 데이터 가져오기
+        OrderBookResponseDTO oldOrderBook = orderBookRedisTemplate.opsForValue().get(cacheKey);
+
+        // 2. 현재 최신 호가창 데이터 계산
+        OrderBookResponseDTO newOrderBook = calculateAndCacheOrderBook(fundingId);
+
+        // 3. 업데이트 DTO를 담을 리스트
+        List<OrderBookUpdateDTO> updates = new ArrayList<>();
+
+        // 이전 데이터가 없으면 전체 호가창을 업데이트로 간주
+        if (oldOrderBook == null) {
+            updates.add(OrderBookUpdateDTO.builder()
+                    .type(OrderBookUpdateDTO.Type.FULL)
+                    .buyOrders(newOrderBook.getBuyOrders())
+                    .sellOrders(newOrderBook.getSellOrders())
+                    .currentPrice(newOrderBook.getCurrentPrice())
+                    .build());
+
+            return updates;
+        }
+
+        // 4. 매수/매도 호가 변경분 비교
+        updates.addAll(findUpdates(oldOrderBook.getBuyOrders(), newOrderBook.getBuyOrders(), OrderType.BUY));
+        updates.addAll(findUpdates(oldOrderBook.getSellOrders(), newOrderBook.getSellOrders(), OrderType.SELL));
+
+        // 5. 현재가 변경분 추가(거래 체결 시에만 변동)
+        if (oldOrderBook.getCurrentPrice().compareTo(newOrderBook.getCurrentPrice()) != 0) {
+            updates.add(OrderBookUpdateDTO.builder()
+                    .type(OrderBookUpdateDTO.Type.PRICE_UPDATE)
+                    .currentPrice(newOrderBook.getCurrentPrice())
+                    .build());
+        }
+
+        return updates;
+    }
+
+    private Map<BigDecimal, Integer> buildOrderBookMap(List<OrderBookEntryDTO> entries) {
+        return entries.stream()
+                .collect(Collectors.toMap(OrderBookEntryDTO::getPrice, OrderBookEntryDTO::getQuantity));
+    }
+
+
+    // 이전 데이터와 새 데이터를 비교하여 변경분을 찾음
+    private List<OrderBookUpdateDTO> findUpdates(List<OrderBookEntryDTO> oldEntries, List<OrderBookEntryDTO> newEntries, OrderType type) {
+        List<OrderBookUpdateDTO> updates = new ArrayList<>();
+        Map<BigDecimal, Integer> oldMap = buildOrderBookMap(oldEntries);
+        Map<BigDecimal, Integer> newMap = buildOrderBookMap(newEntries);
+
+        // 새로운 항목/변경된 항목 찾기
+        for (Map.Entry<BigDecimal, Integer> newEntry : newMap.entrySet()) {
+            BigDecimal price = newEntry.getKey();
+            Integer newQuantity = newEntry.getValue();
+            Integer oldQuantity = oldMap.get(price);
+
+            // 새로운 가격이 추가되었거나 수량이 변경된 경우
+            if (oldQuantity == null || !oldQuantity.equals(newQuantity)) {
+                updates.add(OrderBookUpdateDTO.builder()
+                        .type(oldQuantity == null ? OrderBookUpdateDTO.Type.ADD : OrderBookUpdateDTO.Type.UPDATE)
+                        .price(price)
+                        .quantity(BigDecimal.valueOf(newQuantity))
+                        .build());
+            }
+        }
+
+        // 삭제된 항목 찾기
+        for (Map.Entry<BigDecimal, Integer> oldEntry : oldMap.entrySet()) {
+            BigDecimal price = oldEntry.getKey();
+            if (!newMap.containsKey(price)) {
+                updates.add(OrderBookUpdateDTO.builder()
+                        .type(OrderBookUpdateDTO.Type.REMOVE)
+                        .price(price)
+                        .quantity(BigDecimal.valueOf(0)) // 수량 0으로 설정하여 삭제 신호 보냄
+                        .build());
+            }
+        }
+
+        return updates;
+    }
+
+    // 호가창을 계산하고 캐시에 저장하는 로직을 별도의 메서드로 분리
+    private OrderBookResponseDTO calculateAndCacheOrderBook(Long fundingId) {
         // 현재가 계산 (가장 최근의 체결 가격 조회)
         BigDecimal latestTradePrice = tradeMapper.findLatestTradePriceByFundingId(fundingId);
         BigDecimal currentPrice;
@@ -68,19 +147,15 @@ public class OrderBookServiceImpl implements OrderBookService{
             currentPrice = funding.getCurrentShareAmount();
         }
 
-        // 3. 상한가/하한가 계산
+        // 상한가/하한가 계산
         BigDecimal upperLimitPrice = currentPrice.multiply(BigDecimal.ONE.add(LIMIT_PERCENTAGE))
                 .setScale(2, RoundingMode.HALF_UP);
         BigDecimal lowerLimitPrice = currentPrice.multiply(BigDecimal.ONE.subtract(LIMIT_PERCENTAGE))
                 .setScale(2, RoundingMode.HALF_UP);
 
-        // 4. 매수/매도 호가 잔량 집계
+        // 매수/매도 호가 잔량 집계
         List<OrderVO> activeOrders = orderMapper.findOrdersByFundingId(fundingId);
-
-
-        // 매수 호가 집계 (가격 내림차순 정렬)
         List<OrderBookEntryDTO> buyOrders = buildOrderBook(activeOrders, OrderType.BUY, Comparator.reverseOrder());
-        // 매도 호가 집계 (가격 오름차순 정렬)
         List<OrderBookEntryDTO> sellOrders = buildOrderBook(activeOrders, OrderType.SELL, Comparator.naturalOrder());
 
         OrderBookResponseDTO orderBook = OrderBookResponseDTO.builder()
@@ -92,16 +167,11 @@ public class OrderBookServiceImpl implements OrderBookService{
                 .timestamp(LocalDateTime.now())
                 .build();
 
-        // 4. 계산된 데이터를 캐시에 저장 (예: 30초 TTL 설정)
+        // 계산된 데이터를 캐시에 저장 (예: 30초 TTL 설정)
+        String cacheKey = "orderBook:" + fundingId;
         orderBookRedisTemplate.opsForValue().set(cacheKey, orderBook, 30, TimeUnit.SECONDS);
 
         return orderBook;
-    }
-
-    @Override
-    public void evictOrderBookCache(Long fundingId) {
-        String cacheKey = "orderBook:" + fundingId;
-        orderBookRedisTemplate.delete(cacheKey);
     }
 
     private List<OrderBookEntryDTO> buildOrderBook(List<OrderVO> orders, OrderType type, Comparator<BigDecimal> sortOrder) {


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [x] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
호가창 실시간 업데이트 시 발생하는 불필요한 네트워크 트래픽을 개선하고, 사용자에게 더 빠르고 정확한 호가창 정보를 제공하기 위해 로직을 리팩토링했습니다. 
기존에 호가창 변동이 생길 때마다 전체 호가창을 전송하던 방식에서, **변경된 부분**만 추출하여 전송하도록 변경했습니다.

## 🚀 전체 로직 흐름
1. **최초 조회**: 클라이언트가 호가창을 요청하면, `OrderBookService`는 Redis 캐시에 데이터가 있는지 확인합니다.
2. **캐시 미스**: 캐시에 데이터가 없으면 DB에서 전체 호가창 정보를 계산하고, 이를 Redis에 저장합니다.
3. **실시간 업데이트**: 주문이 들어오거나 취소되면, `updateOrderBookAndSendUpdates` 메서드가 호출됩니다.
    * 이 메서드는 Redis에 저장된 **이전 호가창**을 가져옵니다.
    * DB에서 최신 호가창을 다시 계산하며, 이 과정에서 Redis에 있는 **기존 캐시를 최신 데이터로 갱신**합니다.
    * 가져온 이전 호가창과 새롭게 계산된 최신 호가창을 비교하여 변경분을 찾아냅니다.
    * 마지막으로, 발견된 **변경분만** 클라이언트에게 웹소켓으로 전송합니다. 이로써 불필요한 네트워크 트래픽을 최소화하고, 실시간성을 확보합니다.


## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항


## 📎 관련 이슈
Close #이슈번호
